### PR TITLE
Feature - 2nd Case - Filtering empty WikiIds

### DIFF
--- a/src/main/java/it/cnr/isti/hpc/wikipedia/parser/ArticleParser.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/parser/ArticleParser.java
@@ -318,28 +318,28 @@ public class ArticleParser {
 
     private Pair<List<Link>, List<Link>> extractLinks(List<de.tudarmstadt.ukp.wikipedia.parser.Link> links){
 
-        List<Link> internalLinks = new ArrayList<Link>(10);
-        List<Link> externalLinks = new ArrayList<Link>(10);
+		List<Link> internalLinks = new ArrayList<Link>(10);
+		List<Link> externalLinks = new ArrayList<Link>(10);
 
-        for (de.tudarmstadt.ukp.wikipedia.parser.Link t : links) {
-            if (t.getType() == de.tudarmstadt.ukp.wikipedia.parser.Link.type.INTERNAL) {
-                if(!t.getTarget().equals(""))
-                    internalLinks.add(new Link(t.getTarget(), t.getText(), t.getPos().getStart(), t.getPos().getEnd()));
-            }
-            if (t.getType() == de.tudarmstadt.ukp.wikipedia.parser.Link.type.EXTERNAL) {
-                externalLinks.add(new Link(t.getTarget(), t.getText(),t.getPos().getStart(), t.getPos().getEnd()));
-            }
-        }
+		for (de.tudarmstadt.ukp.wikipedia.parser.Link t : links) {
+			if (t.getType() == de.tudarmstadt.ukp.wikipedia.parser.Link.type.INTERNAL) {
+				if(!t.getTarget().equals(""))
+					internalLinks.add(new Link(t.getTarget(), t.getText(), t.getPos().getStart(), t.getPos().getEnd()));
+			}
+			if (t.getType() == de.tudarmstadt.ukp.wikipedia.parser.Link.type.EXTERNAL) {
+				externalLinks.add(new Link(t.getTarget(), t.getText(),t.getPos().getStart(), t.getPos().getEnd()));
+			}
+		}
 
-        return Pair.of(internalLinks, externalLinks);
+		return Pair.of(internalLinks, externalLinks);
     }
 
 
 	private void setLinks(Article article, ParsedPage page) {
-        Pair<List<Link>,List<Link>> extractedLinks = extractLinks(page.getLinks());
+		Pair<List<Link>,List<Link>> extractedLinks = extractLinks(page.getLinks());
 
-        List<Link> links = extractedLinks.getLeft();
-        List<Link> elinks = extractedLinks.getRight();
+		List<Link> links = extractedLinks.getLeft();
+		List<Link> elinks = extractedLinks.getRight();
 
 		article.setLinks(links);
 		article.setExternalLinks(elinks);
@@ -426,11 +426,11 @@ public class ArticleParser {
 			if (!text.isEmpty()){
 				paragraphs.add(text);
 
-                Pair<List<Link>,List<Link>> extractedLinks = extractLinks(p.getLinks());
-                // internal links
-                links = extractedLinks.getLeft();
+				Pair<List<Link>,List<Link>> extractedLinks = extractLinks(p.getLinks());
+				// internal links
+				links = extractedLinks.getLeft();
 
-                ParagraphWithLinks paragraphWithLinks = new ParagraphWithLinks(text, links);
+				ParagraphWithLinks paragraphWithLinks = new ParagraphWithLinks(text, links);
 				paraLinks.add(paragraphWithLinks);
 			}
 		}

--- a/src/test/java/it/cnr/isti/hpc/wikipedia/article/en/ArticleTest.java
+++ b/src/test/java/it/cnr/isti/hpc/wikipedia/article/en/ArticleTest.java
@@ -141,4 +141,18 @@ public class ArticleTest {
 
     }
 
+    @Test
+    public void testEmptyLinksShouldBeFiltered() throws IOException {
+        // Some annotations are incomplete on wikipedia i.e: [[]] [[ ]]
+        // Those should be filtered
+        Article a = new Article();
+        String mediawiki = IOUtils.getFileAsUTF8String("./src/test/resources/en/Phantom_kangaroo");
+        parser.parse(a, mediawiki);
+
+        for(Link l: a.getLinks()){
+            assert(!l.getId().equals(""));
+            assert(!l.getAnchor().equals(""));
+        }
+    }
+
 }

--- a/src/test/resources/en/Phantom_kangaroo
+++ b/src/test/resources/en/Phantom_kangaroo
@@ -1,0 +1,64 @@
+
+==France==
+It is sometimes said there is a population of kangaroos living in the wild in the township of [[]], about 50&amp;nbsp;km south-west of Paris.&lt;ref&gt;{{cite web|url=http://www.smh.com.au/news/world/roos-are-driving-french-hopping-mad/2006/02/11/1139542445052.html |title=Roos are driving French hopping mad |publisher=Smh.com.au |date=29 July 2009 |accessdate=2010-03-02}}&lt;/ref&gt; In fact, they are [[Wallaby|wallabies]].&lt;ref&gt;{{cite web|title=Des wallabies en liberté dans ma forêt de Rambouillet|url=http://passionnature78.canalblog.com/archives/2008/06/04/9442980.html|publisher=Passion Nature 78|accessdate=4 June 2013}}&lt;/ref&gt; These wallabies are descended from a breeding population which escaped during a botched burglary attempt at an animal park in the 1970s.
+
+==Poland==
+There is a documented population of kangaroos about 50&amp;nbsp;km Southwest of Kraków, near the Slovakian border.  The colony originated from a pair of kangaroos that escaped from a local zoo and found refuge in the border area where ongoing Polish-Slovak territorial disputes have created a wide swath of demilitarized wilderness.  The colony now numbers between 50 and 85 kangaroos.&lt;ref name=simons&gt;{{cite book
+  | last = Simons
+  | first =  John
+  | title = Kangaroo
+  | publisher =  Reaktion Books - Animal
+  |year=2012
+  | location =  Chicago
+  | pages =
+  | url =
+  | doi =
+  | isbn = 9781861899224
+ }}&lt;/ref&gt;
+
+==Germany==
+In the years before [[World War I]], there was a colony of wallabies in [[Prussia]], raised by a hunter living there.  When he died, shortly before WWI, they became easy prey to local deer hunters.
+
+==Japan==
+Between 2003 and 2010, there was a series of phantom kangaroo sightings in the Mayama mountain district of [[Ōsaki, Miyagi]] city in [[Miyagi Prefecture]]&lt;ref&gt;{{cite web|url=http://www.abc.net.au/news/stories/2010/03/09/2840119.htm |title=Phantom kangaroos spotted in Japan |publisher=ABC.net.au |date=9 March 2010 |accessdate=2010-03-11}}&lt;/ref&gt;
+
+==New Zealand==
+In 1831 two men off the [[Sydney Packet]] reported to the Collector of Customers in Australia that they had seen a giant kangaroo (nine meters in standing) at a small cove in [[Dusky Sound]]. They observed it on the bushline from a small boat and when they came too close it leapt into the water and ploughed through the water, leaving a wake extending from end of the sound to the other.&lt;ref name=Gosset1996&gt;{{cite book|last=Gosset|first=Robyn|title=New Zealand Mysteries|publisher=The Bush Press of New Zealand|isbn=0-908608-73-X|pages=148–149}}&lt;/ref&gt;
+
+[[Kawau Island]] in the [[Hauraki Gulf]] has a colony of three species of wallabies descending from a deliberate introduction by [[George Edward Grey|Sir George Grey]], a nineteenth century [[Governor-General of New Zealand|Governor]].&lt;ref&gt;{{cite news|title=The Hauraki Gulf Marine Park, Part 2|date=3 March 2010|work=Inset to [[The New Zealand Herald]]|pages=12}}&lt;/ref&gt;
+
+==United Kingdom==
+Documented colonies of [[Red-necked Wallaby|red-necked wallabies]] exist in the United Kingdom. In [[Staffordshire]], a breeding colony has established itself after breaking loose from a private zoo in  Leek, [[Staffordshire]] in the 1930s.&lt;ref&gt;{{cite web|url=http://www.bbc.co.uk/dna/h2g2/A786477 |title=Derbyshire's Wallabies |publisher=Bbc.co.uk |date= |accessdate=2010-03-02}}&lt;/ref&gt;  Their population peaked in the 1970s, reaching numbers between 60 and 70. There have been no confirmed sightings of the wallabies between 2000 and 2008, with some locals believing they must have died out. However, newspapers reported wallaby sightings in July 2009 (including clear pictures) and made reference to sightings in 2008. Other Wallaby colonies exist in the UK, including reliable reports from the Fenland on the Norfolk/Lincolnshire border; and there are a few in [[Ashdown Forest]], Sussex.
+In October 2013 what was reported as a Bennett’s wallaby was filmed by zoologist Maurice Melzak in [[Highgate Cemetery]], Hampstead, London.&lt;ref&gt;{{cite web|url=http://www.telegraph.co.uk/earth/wildlife/10396734/Wallaby-spotted-in-Highgate-Cemetery.html |title=Wallaby spotted in Highgate Cemetery |publisher=The Telegraph |date=2013-10-22 |accessdate=2013-10-22}}&lt;/ref&gt;
+
+In Scotland, [[Inchconnachan]], an island in [[Loch Lomond]] has a population of wallabies as well. Lady Arran Colquhoun introduced them in the 1920s.&lt;ref name=lln&gt;{{cite web| url=http://www.loch-lomond.net/theloch/inchconnachan.aspx| title=Loch Lomond Islands: Inchconnachan| publisher=Loch Lomond.net| accessdate=2013-05-03}}&lt;/ref&gt;
+
+==United States==
+In 1934 near [[South Pittsburg, Tennessee|South Pittsburg]], [[Tennessee]] an [[wikt:atypical|atypical]] kangaroo or &quot;kangaroolike beast&quot; was reported by several witnesses over a five day period,&lt;ref name=&quot;Fort1984&quot;&gt;{{cite book|last=Fort|first=Charles|title=The Info Journal|url=http://books.google.com/books?id=RVklAQAAIAAJ|year=1984|publisher=International Fortean Organization|page=5}}&lt;/ref&gt; and to have killed and partially devoured several animals, including ducks, geese, a [[German Shepherd Dog|German Shepherd]] [[police dog]] and other dogs.&lt;ref name=Clark1998&gt;{{cite book|last=Clark|first=Jerome |title=Unexplained: Strange Sightings, Incredible Occurrences and Puzzling Physical Phenomena|url=http://books.google.com/books?id=WsvTpBvUgrYC&amp;pg=PA392|date=1 November 1998|publisher=Visible Ink Press|isbn=978-1-57859-266-1|pages=392–395}}&lt;/ref&gt;&lt;ref name=Coleman2007&gt;{{cite book|last=Coleman|first=Loren|title=Mysterious America: The Ultimate Guide to the Nation's Weirdest Wonders, Strangest Spots, and Creepiest Creatures|url=http://books.google.com/books?id=Z2UlKsvrX60C&amp;pg=PT149|date=24 April 2007|publisher=Pocket Books|isbn=978-1-4165-3944-5|pages=149–150}}&lt;/ref&gt; Kangaroos are typically unaggressive and vegetarian.&lt;ref name=Clark1998/&gt; A witness described the animal as looking &quot;like a large kangaroo, running and leaping across a field.&quot;&lt;ref name=Clark1998/&gt; A search party followed the animal's tracks to a mountainside cave where they stopped.&lt;ref name=Coleman2007/&gt; The animal was never found, and national news coverage drew widespread ridicule.&lt;ref name=Clark1998/&gt;
+
+In 1974 in [[Chicago]], [[Illinois]], two Chicago police officers were called to investigate a report that a kangaroo was standing in someone's porch. After a brief search, the officers located the animal in an alleyway, but were unable to capture it.&lt;ref name=clark1/&gt; Over the next month, numerous kangaroo sightings were reported in [[Illinois]] and the neighboring states of [[Indiana]] and [[Wisconsin]], with timing suggesting more than one animal if reports were accurate.&lt;ref name=clark1/&gt;&lt;ref name=Coleman2007/&gt; A kangaroo was seen the next day by a paperboy, the next week in [[Forest Preserve District of Cook County#Region 3: North Cook County|Schiller Woods]], Illinois, and the week after that just outside [[Plano, Illinois|Plano]], Illinois, reported by a police officer who said it jumped eight feet from a field into the road. Thirty minutes later a kangaroo was reported back in Chicago, then reported on the following three days in the surrounding countryside. A few days later, there were a rash of sightings in [[Indiana]]. Reports ceased about a month after the original story.&lt;ref name=Coleman2007/&gt;
+
+In 1978 in [[Menomonee Falls]], [[Wisconsin]], two men photographed a large kangaroo beside the highway.&lt;ref name=clark1/&gt; Author [[Loren Coleman]], described as the &quot;leading authority on North American kangaroo sightings&quot;, suggested the animal looked like a [[Bennett's wallaby]].
+
+In 2013 in [[Oklahoma]] a kangaroo was reportedly recorded by hunters in a field.&lt;ref name=mckinnon2013&gt;{{cite news | title=Oklahoma hunter catches kangaroo on camera | date=24 December 2013 | last=McKinnon | first=Chris | work=News 9 | location=Oklahoma | publisher=World Now and KWTV | url=http://www.news9.com/story/24299464/oklahoma-hunter-catches-kangaroo-on-camera | accessdate=25 December 2013}}&lt;/ref&gt; The video was published on the website [[YouTube]], and prompted speculation that the animal may be a pet kangaroo who went missing in the state just over a year earlier.&lt;ref name=mckinnon2013/&gt;&lt;ref&gt;{{cite news | title=The search for Lucy Sparkles | work=News 12 | last=McLinden | first=Scott | date=30 November 2012 | publisher=Gray Television, Inc. | url=http://www.kxii.com/news/headlines/The-search-for-Lucy-Sparkles-181641051.html | accessdate=25 December 2013 }}&lt;/ref&gt;
+
+Also in 2013, [[The Ridgefield Press]] reported that a motorist in [[North Salem, New York]] captured on video what he thought was a kangaroo, and published the video on their website.&lt;ref name=ridgefield2013&gt;{{cite news | url=http://www.theridgefieldpress.com/19530/ridgefielder-spots-kangaroo-on-route-116/ | work=The Ridgefield Press | title=Ridgefielder spots ‘kangaroo’ on Route 116 | date=8 July 2013 | accessdate=29 March 2014 }}&lt;/ref&gt; The newspaper noted that escaped wallabies, smaller than kangaroos, were known in [[Westchester County, New York|Westchester County]], which encompasses North Salem.&lt;ref name=ridgefield2013/&gt; Several people in the county had kept wallabies as pets.&lt;ref name=ridgefield2013/&gt;
+
+==See also==
+* [[Forteana]]
+* [[Hippety Hopper]]
+* [[Jersey Devil]]
+* [[Vagrancy (biology)]]
+
+==References==
+{{Reflist}}
+
+==External links==
+*[http://www.prairieghosts.com/gators.html Mysterious Creatures of Illinois: Vanishing Gators, Lions and Phantom Kangaroos]
+*[http://www.newanimal.org/kanga.htm The Cryptid Zoo: Kangaroos in Cryptozoology]
+*[http://www.xprojectmagazine.com/archives/cryptozoology/phantomkangas.html X-Project: Phantom Kangaroos]
+*[http://www.cryptomundo.com/cryptozoo-news/killerroo/ 1934Tennessee sightings]
+
+{{DEFAULTSORT:Phantom Kangaroo}}
+[[Category:Mammal cryptids]]
+[[Category:Legendary mammals]]<


### PR DESCRIPTION
Some articles contain wrong link annotations i.e: `[[]]` or `[[ ]]`

- Filtering links with empty WikiID
- Added tests for a case found on out small wiki