### PR TITLE
Speeding up - Using Spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ In order to use these classes, you will have to install `json-wikipedia` in your
 
 and import the project in your new maven project adding the dependency: 
 
-    <dependency>
-      <groupId>it.cnr.isti.hpc</groupId>
-    <artifactId>json-wikipedia</artifactId>
-    <version>1.0.0</version>
-  </dependency> 
+	<dependency>
+		<groupId>it.cnr.isti.hpc</groupId>
+		<artifactId>json-wikipedia</artifactId>
+		<version>1.0.0</version>
+	</dependency>
   
 #### Schema ####
 

--- a/README.md
+++ b/README.md
@@ -3,26 +3,45 @@ json-wikipedia ![json-wikipedia](https://dl.dropboxusercontent.com/u/4663256/tmp
 
  Json Wikipedia contains code to convert the Wikipedia XML dump into a [JSON][json] dump.
 
-#### Setup ####
+ What's different about this fork:
+ 
+ - Uses Apache Spark to speedup the transformation to json. Original Json-wikipedia runs on a single thread.
+ - Fixes some issues with JWPL, which means less noisy extractions
+ - Chunks the article's pages into paragraphs and returns a list of links with correct spans
+ - Extract Links from article's paragraphs with matching spans
 
-compile the project running 
 
-    mvn assembly:assembly 
-	
-the command will produce a JAR file containing all the dependencies the target folder.  
+## Convert the Wikipedia XML to JSON
 
-#### Convert the Wikipedia XML to JSON ####
+### The Docker way
 
-    java -cp target/json-wikipedia-1.0.0-jar-with-dependencies.jar it.cnr.isti.hpc.wikipedia.cli.MediawikiToJsonCLI -input wikipedia-dump.xml.bz -output wikipedia-dump.json[.gz] -lang [en|it] 		
+Enjoy a dockerized image:
 
-or 
+   `docker run -v <LOCALPATH>:/mnt -i -t dav009/jsonpedia -input <PATHTOWIKI> -output <OUTPUTPATH> -lang <LANG>`
 
-	./scripts/convert-xml-dump-to-json.sh [en|it] wikipedia-dump.xml.bz wikipedia-dump.json[.gz]
+ For example if my `english_wikipedia.dump` lives in : `/david/data/english_wikipedia.dump` I could run it as:
 
-produces in `wikipedia-dump.json` the JSON version of the dump ([here you can find an example](https://dl.dropboxusercontent.com/u/4663256/tmp/json-wikipedia-sample.json)). Each line of the file contains an article 
-of dump encoded in JSON. Each JSON line can be deserialized in an [Article](http://sassicaia.isti.cnr.it/javadocs/json-wikipedia/it/cnr/isti/hpc/wikipedia/article/Article.html) object, 
-which represents an 
-_enriched_ version of the wikitext page. The Article object contains: 
+   `docker run -v /david/data:/mnt -i -t dav009/jsonpedia -input /mnt/english_wikipedia.dump -output /mnt/english_wikipedia.json -lang en`
+
+Note that the output path corresponds to a path within the docker container. In the given example the output path is part of the mounted volume, so it will be available at the host machine.
+
+
+### Doing it yourself
+
+1. Compile the project by doing: `mvn assembly:assembly` the command will produce a JAR file containing all the dependencies the target folder.
+2. Download Spark 1.3.1: http://www.apache.org/dyn/closer.cgi/spark/spark-1.3.1/spark-1.3.1.tgz
+3. Download Wikipedia Dump ( https://dumps.wikimedia.org/backup-index.html )
+4. Uncompress the Wikipedia Dump
+5. do:
+
+    SPARKFOLDER/bin/spark-submit --driver-memory 10G --class it.cnr.isti.hpc.wikipedia.cli.MediawikiToJsonCLI json-wikipedia-1.0.0-jar-with-dependencies.jar -input <PATHTODBPEDIADUMP> -output <PATHTONEWJSONPEDIA> -lang <LANG>
+
+this produces in `<PATHTONEWJSONPEDIA>` the JSON version of the dump
+
+### How does Jsonpedia look like?
+
+ ([here you can find an example](https://dl.dropboxusercontent.com/u/4663256/tmp/json-wikipedia-sample.json)). Each line of the file contains an article
+of dump encoded in JSON. Each JSON line can be deserialized in an [Article](http://sassicaia.isti.cnr.it/javadocs/json-wikipedia/it/cnr/isti/hpc/wikipedia/article/Article.html) object,which represents an_enriched_ version of the wikitext page. The Article object contains:
 
 
   * the title (e.g., Leonardo Da Vinci);
@@ -43,17 +62,17 @@ _enriched_ version of the wikitext page. The Article object contains:
   * a list of terms highlighted in the article;
   * if present, the infobox. 
   
-#### Usage ####
+#### Usage
 
 Once you have created (or downloaded) the JSON dump (say `wikipedia.json`), you can iterate over the articles of the collection 
 easily using this snippet: 
 
     RecordReader<Article> reader = new RecordReader<Article>(
-			"wikipedia.json",new JsonRecordParser<Article>(Article.class)
+      "wikipedia.json",new JsonRecordParser<Article>(Article.class)
     ).filter(TypeFilter.STD_FILTER);
 
     for (Article a : reader) {
-	// do what you want with your articles	
+    // do what you want with your articles  
     }
  
 You can also add some filters in order to iterate only on certain articles (in the example 
@@ -70,11 +89,11 @@ In order to use these classes, you will have to install `json-wikipedia` in your
 and import the project in your new maven project adding the dependency: 
 
     <dependency>
-	    <groupId>it.cnr.isti.hpc</groupId>
-		<artifactId>json-wikipedia</artifactId>
-		<version>1.0.0</version>
-	</dependency> 
-	
+      <groupId>it.cnr.isti.hpc</groupId>
+    <artifactId>json-wikipedia</artifactId>
+    <version>1.0.0</version>
+  </dependency> 
+  
 #### Schema ####
 
 ```

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ json-wikipedia ![json-wikipedia](https://dl.dropboxusercontent.com/u/4663256/tmp
 
 Enjoy a dockerized image:
 
-   `docker run -v <LOCALPATH>:/mnt -i -t dav009/jsonpedia -input <PATHTOWIKI> -output <OUTPUTPATH> -lang <LANG>`
+   `docker run -v <LOCALPATH>:/mnt -i -t dav009/jsonwikipedia  -input <PATHTOWIKI> -output <OUTPUTPATH> -lang <LANG>`
 
  For example if my `english_wikipedia.dump` lives in : `/david/data/english_wikipedia.dump` I could run it as:
 
-   `docker run -v /david/data:/mnt -i -t dav009/jsonpedia -input /mnt/english_wikipedia.dump -output /mnt/english_wikipedia.json -lang en`
+   `docker run -v /david/data:/mnt -i -t dav009/jsonwikipedia -input /mnt/english_wikipedia.dump -output /mnt/english_wikipedia.json -lang en`
 
 Note that the output path corresponds to a path within the docker container. In the given example the output path is part of the mounted volume, so it will be available at the host machine.
 
@@ -34,14 +34,14 @@ Note that the output path corresponds to a path within the docker container. In 
 4. Uncompress the Wikipedia Dump
 5. do:
 
-    SPARKFOLDER/bin/spark-submit --driver-memory 10G --class it.cnr.isti.hpc.wikipedia.cli.MediawikiToJsonCLI json-wikipedia-1.0.0-jar-with-dependencies.jar -input <PATHTODBPEDIADUMP> -output <PATHTONEWJSONPEDIA> -lang <LANG>
+	SPARKFOLDER/bin/spark-submit --driver-memory 10G --class it.cnr.isti.hpc.wikipedia.cli.MediawikiToJsonCLI json-wikipedia-1.0.0-jar-with-dependencies.jar -input <PATHTODBPEDIADUMP> -output <PATHTONEWJSONPEDIA> -lang <LANG>
 
 this produces in `<PATHTONEWJSONPEDIA>` the JSON version of the dump
 
 ### How does Jsonpedia look like?
 
  ([here you can find an example](https://dl.dropboxusercontent.com/u/4663256/tmp/json-wikipedia-sample.json)). Each line of the file contains an article
-of dump encoded in JSON. Each JSON line can be deserialized in an [Article](http://sassicaia.isti.cnr.it/javadocs/json-wikipedia/it/cnr/isti/hpc/wikipedia/article/Article.html) object,which represents an_enriched_ version of the wikitext page. The Article object contains:
+of dump encoded in JSON. Each JSON line can be deserialized in an [Article](http://sassicaia.isti.cnr.it/javadocs/json-wikipedia/it/cnr/isti/hpc/wikipedia/article/Article.html) object,which represents an _enriched_ version of the wikitext page. The Article object contains:
 
 
   * the title (e.g., Leonardo Da Vinci);
@@ -67,13 +67,13 @@ of dump encoded in JSON. Each JSON line can be deserialized in an [Article](http
 Once you have created (or downloaded) the JSON dump (say `wikipedia.json`), you can iterate over the articles of the collection 
 easily using this snippet: 
 
-    RecordReader<Article> reader = new RecordReader<Article>(
-      "wikipedia.json",new JsonRecordParser<Article>(Article.class)
-    ).filter(TypeFilter.STD_FILTER);
+	RecordReader<Article> reader = new RecordReader<Article>(
+	  "wikipedia.json",new JsonRecordParser<Article>(Article.class)
+	).filter(TypeFilter.STD_FILTER);
 
-    for (Article a : reader) {
-    // do what you want with your articles  
-    }
+	for (Article a : reader) {
+		// do what you want with your articles
+	}
  
 You can also add some filters in order to iterate only on certain articles (in the example 
 we used only the standard type filter, which excludes meta pages e.g., Portal: or User: pages.).
@@ -84,7 +84,7 @@ of the [hpc-utils](http://sassicaia.isti.cnr.it/javadocs/hpc-utils) package.
 
 In order to use these classes, you will have to install `json-wikipedia` in your maven repository:
 
-    mvn install
+	mvn install
 
 and import the project in your new maven project adding the dependency: 
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>it.cnr.isti.hpc</groupId>
 	<artifactId>json-wikipedia</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 	<name>Json Wikipedia</name>
 	<description>Json Wikipedia contains code to parse a Wikipedia dump</description>
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,16 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.1</version>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.10</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.10.3</version>
+        </dependency>
 	</dependencies>
 	<!-- repositories> <repository> <id>lilyproject</id> <url>http://www.lilyproject.org/maven/maven2/deploy/</url> 
 		<releases> <enabled>true</enabled> </releases> <snapshots> <enabled>false</enabled> 
@@ -113,6 +123,17 @@
 		<repository>
 			<id>jitpack.io</id>
 			<url>https://jitpack.io</url>
+		</repository>
+		<repository>
+			<id>scala</id>
+			<name>Scala Tools</name>
+			<url>http://scala-tools.org/repo-releases/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 	<build>
@@ -151,6 +172,34 @@
 					<destDir>javadoc</destDir>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
+						<goals>
+						<goal>add-source</goal>
+						<goal>compile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>scala</id>
+            <name>Scala Tools</name>
+            <url>http://scala-tools.org/repo-releases/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/src/main/java/it/cnr/isti/hpc/wikipedia/cli/MediawikiToJsonCLI.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/cli/MediawikiToJsonCLI.java
@@ -17,8 +17,10 @@ package it.cnr.isti.hpc.wikipedia.cli;
 
 import it.cnr.isti.hpc.cli.AbstractCommandLineInterface;
 import it.cnr.isti.hpc.wikipedia.article.Article;
-import it.cnr.isti.hpc.wikipedia.reader.WikipediaArticleReader;
+import it.cnr.isti.hpc.wikipedia.spark.JsonpediaRDD;
 
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,14 +102,10 @@ public class MediawikiToJsonCLI extends AbstractCommandLineInterface {
 		String input = cli.getInput();
 		String output = cli.getOutput();
 		String lang = cli.getParam("lang");
-		WikipediaArticleReader wap = new WikipediaArticleReader(input, output,
-				lang);
-		try {
-			wap.start();
-		} catch (Exception e) {
-			logger.error("parsing the mediawiki {}", e.toString());
-			System.exit(-1);
-		}
+		SparkConf conf = new SparkConf().setMaster("local[*]")
+				.setAppName("Mediawiki to Json");
+		SparkContext sc = new SparkContext(conf);
+		new JsonpediaRDD(input, lang, sc).parse().saveAsTextFile(output);
 	}
 
 }

--- a/src/main/java/it/cnr/isti/hpc/wikipedia/reader/JsonpediaReader.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/reader/JsonpediaReader.java
@@ -1,0 +1,25 @@
+package it.cnr.isti.hpc.wikipedia.reader;
+
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+/**
+ * Created by dav009 on 09/07/15.
+ */
+public class JsonpediaReader {
+
+    private String lang;
+    private String XMLInput;
+
+    public JsonpediaReader(String XMLInput, String lang){
+        this.lang = lang;
+        this.XMLInput = XMLInput;
+    }
+
+    public String getJson() throws IOException, SAXException {
+        WikipediaArticleReader wap = new WikipediaArticleReader(XMLInput, lang);
+        wap.start();
+        return wap.getJson();
+    }
+}

--- a/src/main/java/it/cnr/isti/hpc/wikipedia/reader/WikipediaArticleReader.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/reader/WikipediaArticleReader.java
@@ -56,12 +56,12 @@ public class WikipediaArticleReader {
 
 	private WikiXMLParser wxp;
 	private BufferedWriter out;
-    private String json;
+	private String json;
 
 	private ArticleParser parser;
 	// private JsonRecordParser<Article> encoder;
 
-    private boolean toJsonFile = true;
+	private boolean toJsonFile = true;
 
 	private static ProgressLogger pl = new ProgressLogger("parsed {} articles",
 			10000);
@@ -103,7 +103,7 @@ public class WikipediaArticleReader {
 	 * 
 	 */
 	public WikipediaArticleReader(File inputFile, File outputFile, String lang) {
-        toJsonFile = true;
+		toJsonFile = true;
 		JsonConverter handler = new JsonConverter();
 		// encoder = new JsonRecordParser<Article>(Article.class);
 		parser = new ArticleParser(lang);
@@ -119,19 +119,19 @@ public class WikipediaArticleReader {
 
 	}
 
-    public WikipediaArticleReader(String XMLInput, String lang) {
-        toJsonFile = false;
-        JsonConverter handler = new JsonConverter();
+	public WikipediaArticleReader(String XMLInput, String lang) {
+		toJsonFile = false;
+		JsonConverter handler = new JsonConverter();
 
-        parser = new ArticleParser(lang);
-        try {
-            wxp = new StreamWikiXmlParser(XMLInput, handler);
-        } catch (Exception e) {
-            logger.error("creating the parser {}", e.toString());
-            System.exit(-1);
-        }
+		parser = new ArticleParser(lang);
+		try {
+			wxp = new StreamWikiXmlParser(XMLInput, handler);
+		} catch (Exception e) {
+			logger.error("creating the parser {}", e.toString());
+			System.exit(-1);
+		}
 
-    }
+	}
 
 	/**
 	 * Starts the parsing
@@ -139,8 +139,8 @@ public class WikipediaArticleReader {
 	public void start() throws IOException, SAXException {
 
 		wxp.parse();
-        if (toJsonFile)
-            out.close();
+		if (toJsonFile)
+			out.close();
 		logger.info(sw.stat("articles"));
 	}
 
@@ -189,12 +189,12 @@ public class WikipediaArticleReader {
 			parser.parse(article, page.getText());
 
 			try {
-                if(toJsonFile){
-				    out.write(article.toJson());
-				    out.write("\n");
-                }else{
-                    setJson(article.toJson());
-                }
+				if(toJsonFile){
+					out.write(article.toJson());
+					out.write("\n");
+				}else{
+					setJson(article.toJson());
+				}
 			} catch (IOException e) {
 				logger.error("writing the output file {}", e.toString());
 				System.exit(-1);
@@ -206,11 +206,11 @@ public class WikipediaArticleReader {
 		}
 	}
 
-    public String getJson() {
-        return json;
-    }
+	public String getJson() {
+		return json;
+	}
 
-    public void setJson(String json) {
-        this.json = json;
-    }
+	public void setJson(String json) {
+		this.json = json;
+	}
 }

--- a/src/main/java/it/cnr/isti/hpc/wikipedia/spark/StreamWikiXmlParser.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/spark/StreamWikiXmlParser.java
@@ -1,0 +1,26 @@
+package it.cnr.isti.hpc.wikipedia.spark;
+
+import info.bliki.wiki.dump.IArticleFilter;
+import info.bliki.wiki.dump.WikiXMLParser;
+import org.xml.sax.SAXException;
+
+import java.io.*;
+
+/*
+* @author David Przybilla <david.przybilla@idioplatform.com>
+* */
+public class StreamWikiXmlParser extends WikiXMLParser {
+
+    public StreamWikiXmlParser(String xmlContent, IArticleFilter filter) throws UnsupportedEncodingException,
+            IOException, SAXException, FileNotFoundException {
+        super(getBufferedReaderFromString(xmlContent), filter);
+    }
+
+    public static BufferedReader getBufferedReaderFromString(String XMLInput) throws UnsupportedEncodingException,
+            FileNotFoundException, IOException {
+        BufferedReader br = null;
+        InputStream is = new ByteArrayInputStream(XMLInput.getBytes());
+        br = new BufferedReader(new InputStreamReader(is));
+        return br;
+    }
+}

--- a/src/main/java/it/cnr/isti/hpc/wikipedia/spark/XmlInputFormat.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/spark/XmlInputFormat.java
@@ -22,9 +22,8 @@ import java.nio.charset.StandardCharsets;
 
 /*
 * Most of this class comes from the book : "Advanced Analytics with Spark"
-* https://github.com/sryza/aas
+* Please refer to : https://github.com/sryza/aas for the authors.
 *
-* @author David Przybilla <david.przybilla@idioplatform.com>
 * */
 public class XmlInputFormat extends TextInputFormat {
 

--- a/src/main/java/it/cnr/isti/hpc/wikipedia/spark/XmlInputFormat.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/spark/XmlInputFormat.java
@@ -1,0 +1,159 @@
+package it.cnr.isti.hpc.wikipedia.spark;
+
+import it.cnr.isti.hpc.wikipedia.reader.JsonpediaReader;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+
+/*
+* Most of this class comes from the book : "Advanced Analytics with Spark"
+* https://github.com/sryza/aas
+*
+* @author David Przybilla <david.przybilla@idioplatform.com>
+* */
+public class XmlInputFormat extends TextInputFormat {
+
+    private static final Logger log = LoggerFactory.getLogger(XmlInputFormat.class);
+
+    public static final String START_TAG_KEY = "xmlinput.start";
+    public static final String END_TAG_KEY = "xmlinput.end";
+    public static final String LANG = "en";
+
+    @Override
+    public RecordReader<LongWritable, Text> createRecordReader(InputSplit split, TaskAttemptContext context) {
+        try {
+            return new XmlRecordReader((FileSplit) split, context.getConfiguration());
+        } catch (IOException ioe) {
+            log.warn("Error while creating XmlRecordReader", ioe);
+            return null;
+        }
+    }
+
+    /**
+     * XMLRecordReader class to read through a given xml document to output xml blocks as records as specified
+     * by the start tag and end tag
+     *
+     */
+    public static class XmlRecordReader extends RecordReader<LongWritable, Text> {
+
+        private final byte[] startTag;
+        private final byte[] endTag;
+        private final long start;
+        private final long end;
+        private final FSDataInputStream fsin;
+        private final DataOutputBuffer buffer = new DataOutputBuffer();
+        private LongWritable currentKey;
+        private Text currentValue;
+
+        public XmlRecordReader(FileSplit split, Configuration conf) throws IOException {
+            startTag = conf.get(START_TAG_KEY).getBytes(StandardCharsets.UTF_8);
+            endTag = conf.get(END_TAG_KEY).getBytes(StandardCharsets.UTF_8);
+
+            // open the file and seek to the start of the split
+            start = split.getStart();
+            end = start + split.getLength();
+            Path file = split.getPath();
+            FileSystem fs = file.getFileSystem(conf);
+            fsin = fs.open(split.getPath());
+            fsin.seek(start);
+        }
+
+        private boolean next(LongWritable key, Text value) throws IOException {
+            if (fsin.getPos() < end && readUntilMatch(startTag, false)) {
+                try {
+                    buffer.write(startTag);
+                    if (readUntilMatch(endTag, true)) {
+                        key.set(fsin.getPos());
+                        value.set(buffer.getData(), 0, buffer.getLength());
+                        return true;
+                    }
+                } finally {
+                    buffer.reset();
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void close() throws IOException {
+            fsin.close();
+        }
+
+        @Override
+        public float getProgress() throws IOException {
+            return (fsin.getPos() - start) / (float) (end - start);
+        }
+
+        private boolean readUntilMatch(byte[] match, boolean withinBlock) throws IOException {
+            int i = 0;
+            while (true) {
+                int b = fsin.read();
+                // end of file:
+                if (b == -1) {
+                    return false;
+                }
+                // save to buffer:
+                if (withinBlock) {
+                    buffer.write(b);
+                }
+
+                // check if we're matching:
+                if (b == match[i]) {
+                    i++;
+                    if (i >= match.length) {
+                        return true;
+                    }
+                } else {
+                    i = 0;
+                }
+                // see if we've passed the stop point:
+                if (!withinBlock && i == 0 && fsin.getPos() >= end) {
+                    return false;
+                }
+            }
+        }
+
+        @Override
+        public LongWritable getCurrentKey() throws IOException, InterruptedException {
+            return currentKey;
+        }
+
+        @Override
+        public Text getCurrentValue() throws IOException, InterruptedException {
+            JsonpediaReader jsonWikiParser = new JsonpediaReader(currentValue.toString(), LANG);
+            try {
+                return new Text(jsonWikiParser.getJson());
+            }
+            catch (Exception e){
+                System.out.println("Error parsing wikipedia page");
+                return new Text(new String("Error parsing wikipedia page"));
+            }
+        }
+
+        @Override
+        public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+        }
+
+        @Override
+        public boolean nextKeyValue() throws IOException, InterruptedException {
+            currentKey = new LongWritable();
+            currentValue = new Text();
+            return next(currentKey, currentValue);
+        }
+    }
+}

--- a/src/main/scala/it/cnr/isti/hpc/wikipedia/spark/JsonpediaRDD.scala
+++ b/src/main/scala/it/cnr/isti/hpc/wikipedia/spark/JsonpediaRDD.scala
@@ -1,0 +1,26 @@
+package it.cnr.isti.hpc.wikipedia.spark
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.{LongWritable, Text}
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD;
+
+/*
+* @author David Przybilla <david.przybilla@idioplatform.com>
+* */
+
+class JsonpediaRDD(pathToWiki:String, lang:String, sc:SparkContext){
+
+  def parse():RDD[String]={
+
+    val conf = new Configuration();
+    conf.set(XmlInputFormat.START_TAG_KEY, "<page>");
+    conf.set(XmlInputFormat.END_TAG_KEY, "</page>");
+    conf.set(XmlInputFormat.LANG, lang);
+
+    val jsonArticles = sc.newAPIHadoopFile(pathToWiki, classOf[XmlInputFormat], classOf[LongWritable],
+      classOf[Text], conf)
+    jsonArticles.map(_._2.toString)
+  }
+
+}


### PR DESCRIPTION
Transforming a wiki to jsonwiki TAKES AGES. Literally one day. Running in one core.

This PR makes jsonpedia work with spark.

- assumes the input wikipedia is uncompressed. (yes those gz, bz files won't work)
- instead of calling the CLI, to use it we just spark-submit the CLI class 

`bin/spark-submit --driver-memory 10G --class it.cnr.isti.hpc.wikipedia.cli.MediawikiToJsonCLI  /Users/dav009/source/idio-jsonwiki/json-wikipedia/target/json-wikipedia-1.0.0-jar-with-dependencies.jar -input /Users/dav009/enwiki-20150403-small -output ~/output_spark/new_jsonpedia -lang en`

tested this locally