### PR TITLE
Fix - Adding annotations from Tables & Lists

### DIFF
--- a/src/main/java/it/cnr/isti/hpc/wikipedia/parser/ArticleParser.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/parser/ArticleParser.java
@@ -413,12 +413,62 @@ public class ArticleParser {
 
 	}
 
+	/*
+	* Extracts text and links from tables and returns a list of paragraphs
+	* */
+	private List<Paragraph> getParagraphsInTables(ParsedPage page){
+		List<Paragraph> paragraphsInTables = new ArrayList<Paragraph>();
+		for(de.tudarmstadt.ukp.wikipedia.parser.Table t: page.getTables()){
+			for(Paragraph p: t.getParagraphs()){
+				paragraphsInTables.add(p);
+			}
+		}
+		return paragraphsInTables;
+	}
+
+	/*
+	* Extracts text and links from Lists and returns a list of paragraphs
+	* */
+	private List<Paragraph> getParagraphsInList(ParsedPage page){
+		List<Paragraph> paragraphsInLists = new ArrayList<Paragraph>();
+		for (DefinitionList dl : page.getDefinitionLists()) {
+			for (ContentElement c : dl.getDefinitions()) {
+				Paragraph p = new Paragraph(Paragraph.type.NORMAL);
+				p.setText(c.getText());
+				p.setLinks(c.getLinks());
+				paragraphsInLists.add(p);
+			}
+		}
+
+
+		for (NestedListContainer dl : page.getNestedLists()) {
+			List<String> l = new ArrayList<String>();
+			for (NestedList nl : dl.getNestedLists()){
+				Paragraph p = new Paragraph(Paragraph.type.NORMAL);
+				p.setText(nl.getText());
+				p.setLinks(nl.getLinks());
+				paragraphsInLists.add(p);
+			}
+
+		}
+		return paragraphsInLists;
+	}
+
 	private void setParagraphs(Article article, ParsedPage page) {
 		List<String> paragraphs = new ArrayList<String>(page.nrOfParagraphs());
 
-        List<ParagraphWithLinks> paraLinks = new ArrayList<ParagraphWithLinks>();
+		List<ParagraphWithLinks> paraLinks = new ArrayList<ParagraphWithLinks>();
 
-		for (Paragraph p : page.getParagraphs()) {
+		List<Paragraph> AllParagraphs =  new ArrayList<Paragraph>();
+		// Paragraphs extracted from page
+		AllParagraphs.addAll(page.getParagraphs());
+		// Converting table's text into paragraphs
+		AllParagraphs.addAll(getParagraphsInTables(page));
+		// Converting list's text into paragarphs
+		AllParagraphs.addAll(getParagraphsInList(page));
+
+
+		for (Paragraph p : AllParagraphs) {
 			String text = p.getText();
 			List<Link> links = new ArrayList<Link>();
 

--- a/src/test/java/it/cnr/isti/hpc/wikipedia/article/en/ArticleTest.java
+++ b/src/test/java/it/cnr/isti/hpc/wikipedia/article/en/ArticleTest.java
@@ -188,7 +188,6 @@ public class ArticleTest {
 		assertThat(uris, hasItems("Yū_Hayami", "Takumi_Hayami", "Hayami_District,_Ōita", "Mokomichi_Hayami"));
 		assertThat(anchors, hasItems("Takumi Hayami", "Dogen Handa", "Sky Girls"));
 		testAnchorsInText(a);
-
     }
 
 
@@ -212,12 +211,10 @@ public class ArticleTest {
 	* they have been extracted from.
 	* */
 	private void testAnchorsInText(Article article){
-		// first paragraph
 		for(ParagraphWithLinks p:  article.getParagraphsWithLinks()){
 			for(Link link: p.getLinks()){
 				String anchorInPar = p.getParagraph().substring(link.getStart(),link.getEnd() );
 				assertEquals(anchorInPar, link.getAnchor());
-
 			}
 		}
 	}

--- a/src/test/java/it/cnr/isti/hpc/wikipedia/article/en/ArticleTest.java
+++ b/src/test/java/it/cnr/isti/hpc/wikipedia/article/en/ArticleTest.java
@@ -17,6 +17,9 @@ package it.cnr.isti.hpc.wikipedia.article.en;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+import static org.junit.matchers.JUnitMatchers.*;
+
 import it.cnr.isti.hpc.io.IOUtils;
 import it.cnr.isti.hpc.wikipedia.article.Article;
 import it.cnr.isti.hpc.wikipedia.article.Language;
@@ -26,6 +29,8 @@ import it.cnr.isti.hpc.wikipedia.parser.ArticleParser;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import it.cnr.isti.hpc.wikipedia.reader.WikipediaArticleReader;
 import org.junit.Test;
@@ -141,6 +146,52 @@ public class ArticleTest {
 
     }
 
+
+    @Test
+    public void testAnnotationsInTables() throws IOException {
+		Article a = new Article();
+		String mediawiki = IOUtils.getFileAsUTF8String("./src/test/resources/en/International_Military_Tribunal_for_the_Far_East");
+		parser.parse(a, mediawiki);
+
+		List<String> uris = new ArrayList<String>();
+		List<String> anchors = new ArrayList<String>();
+
+		for (ParagraphWithLinks p : a.getParagraphsWithLinks()) {
+			for(Link l:p.getLinks()){
+				uris.add(l.getId());
+				anchors.add(l.getAnchor());
+			}
+
+		}
+
+		assertThat(uris, hasItems("Hsiang_Che-chun", "Arthur_Strettell_Comyns_Carr", "New_Zealand_Army"));
+		assertThat(anchors, hasItems("Hsiang Che-chun", "Arthur Strettell Comyns Carr", "New Zealand Army"));
+		testAnchorsInText(a);
+    }
+
+    @Test
+    public void testAnnotationsInLists() throws IOException {
+        Article a = new Article();
+        String mediawiki = IOUtils.getFileAsUTF8String("./src/test/resources/en/Hayami");
+        parser.parse(a, mediawiki);
+
+		List<String> uris = new ArrayList<String>();
+		List<String> anchors = new ArrayList<String>();
+
+		for (ParagraphWithLinks p : a.getParagraphsWithLinks()) {
+			for(Link l:p.getLinks()){
+				uris.add(l.getId());
+				anchors.add(l.getAnchor());
+			}
+		}
+
+		assertThat(uris, hasItems("Yū_Hayami", "Takumi_Hayami", "Hayami_District,_Ōita", "Mokomichi_Hayami"));
+		assertThat(anchors, hasItems("Takumi Hayami", "Dogen Handa", "Sky Girls"));
+		testAnchorsInText(a);
+
+    }
+
+
     @Test
     public void testEmptyLinksShouldBeFiltered() throws IOException {
         // Some annotations are incomplete on wikipedia i.e: [[]] [[ ]]
@@ -154,5 +205,21 @@ public class ArticleTest {
             assert(!l.getAnchor().equals(""));
         }
     }
+
+
+	/*
+	* Matches the extracted anchors and spans against the text
+	* they have been extracted from.
+	* */
+	private void testAnchorsInText(Article article){
+		// first paragraph
+		for(ParagraphWithLinks p:  article.getParagraphsWithLinks()){
+			for(Link link: p.getLinks()){
+				String anchorInPar = p.getParagraph().substring(link.getStart(),link.getEnd() );
+				assertEquals(anchorInPar, link.getAnchor());
+
+			}
+		}
+	}
 
 }

--- a/src/test/resources/en/Hayami
+++ b/src/test/resources/en/Hayami
@@ -1,0 +1,23 @@
+'''Hayami''' (written: 速見, 速水 or 早見) is a [[Japanese surname]] and can refer to:
+*[[Yuji Hayami]], science fiction and fantasy writer.
+*[[Masaru Hayami]] (1925-2009), Japanese businessman from Kobe.
+*[[Yū Hayami]], J-pop singer and TV actress.
+*[[Mokomichi Hayami]] (born 1984), Japanese actor.
+*[[Gyoshū Hayami]] (1894-1935), Japanese painter in the Nihonga style.
+*[[Saori Hayami]] (born 1991), Japanese voice actress and singer.
+*[[Shō Hayami]] (born 1958), Japanese voice actor and singer. 
+*[[Noriko Hayami]] (born 1959), Japanese actress.
+* [[Dogen Handa]] (1914-1974), known as Hayami Handa, a professional Go player.
+
+'''Fictional characters:'''
+*[[Atsushi Hayami]], one of the main protagonists in ''[[Gunparade March]]''.
+*[[Daisuke Hayami]], from ''[[MegaMan NT Warrior]]'' (''Rockman EXE'') anime and manga.
+*Kohinata Hayami, ''[[H2O: Footprints in the Sand]]'' character.
+*Rena Hayami, ''[[R:Racing Evolution]]'' character.
+*[[Takumi Hayami]], ''[[Sky Girls]]'' character.
+
+==See also==
+*[[Hayami District, Ōita]]
+
+[[Category:Japanese-language surnames]]
+{{surname}}

--- a/src/test/resources/en/International_Military_Tribunal_for_the_Far_East
+++ b/src/test/resources/en/International_Military_Tribunal_for_the_Far_East
@@ -1,0 +1,628 @@
+{{Redirect|Tokyo Trial|the 1983 film|Tokyo Trial (1983 film)|the 2006 film|Tokyo Trial (2006 film)}}
+[[File:International Military Tribunal Ichigaya Court.jpg|thumb|The International Military Tribunal for the Far East was convened at Ichigaya Court, formerly the Imperial Japanese Army HQ building, in [[Ichigaya]], Tokyo.]]
+
+The '''International Military Tribunal for the Far East''' (IMTFE), also known as the '''Tokyo Trials''', the '''Tokyo War Crimes Tribunal''', or simply '''the Tribunal''', was convened on April 29, 1946, to [[criminal procedure|try]] the leaders of the [[Empire of Japan]] for three types of [[war crime]]s. "Class A" crimes were reserved for those who participated in a [[Crime against peace|joint conspiracy to start and wage war]], and were brought against those in the highest decision-making bodies; "Class B" crimes were reserved for those who committed "conventional" atrocities or [[crimes against humanity]]; "Class C" crimes were reserved for those in "the planning, ordering, authorization, or failure to prevent such transgressions at higher levels in the command structure".{{Citation needed|date=November 2011}}
+
+Twenty-eight Japanese military and political leaders were charged with waging aggressive war and with responsibility for conventional war crimes. More than 5,700 lower-ranking personnel were charged with conventional war crimes in separate trials convened by [[Australia]], [[Nationalist Government|China]], [[France]], The [[Netherlands]], the [[Philippines]], the [[United Kingdom]] and the [[United States]]. The charges covered a wide range of crimes including prisoner abuse, rape, sexual slavery, torture, ill-treatment of labourers, execution without trial and inhumane medical experiments. [[Nationalist Government|China]] held 13 tribunals, resulting in 504 convictions and 149 executions.
+
+The [[Emperor of Japan|Japanese Emperor]] [[Hirohito]] and all members of the imperial family, such as career officer [[Prince Yasuhiko Asaka]], were not prosecuted for involvement in any of the three categories of crimes. [[Herbert Bix]] explained, "the [[Truman administration]] and [[General MacArthur]] both believed the occupation reforms would be implemented smoothly if they used Hirohito to legitimise their changes".<ref name="Bix 2012">{{cite web |url= http://www.harpercollins.com/author/authorExtra.aspx?authorID=13941&isbn13=9780060931308&displayType=bookinterview |title=Herbert P. Bix on ''Hirohito and the Making of Modern Japan''| publisher = HarperCollins |accessdate=May 9, 2012}}</ref> As many as 50 suspects, such as [[Nobusuke Kishi]], who later became Prime Minister, and [[Yoshisuke Aikawa]], head of [[Nissan]], were charged but released in 1947 and 1948. [[Shiro Ishii]] received immunity in exchange for data gathered from his experiments on live prisoners. The lone dissenting judge to exonerate all indictees was [[India]]n [[jurist]] [[Radhabinod Pal]].
+
+The tribunal was adjourned on November 12, 1948.
+
+==Background==
+
+The Tribunal was established to implement the [[Cairo Declaration]], the [[Potsdam Declaration]], the [[Japanese Instrument of Surrender|Instrument of Surrender]], and the [[Moscow Conference (1945)|Moscow Conference]]. The Potsdam Declaration had called for trials and purges of those who had "deceived and misled" the Japanese people into war. However, there was major disagreement, both among the [[Allies of World War II|Allies]] and within their administrations, about whom to try and how to try them. Despite the lack of consensus, General [[Douglas MacArthur]], the [[Supreme Commander of the Allied Powers]], decided to initiate arrests. On September 11, a week after the surrender, he ordered the arrest of 39 suspects—most of them members of General [[Hideki Tōjō]]'s war cabinet. Tōjō tried to commit suicide, but was resuscitated with the help of U.S. doctors.
+
+==Creation of the court==
+[[File:IMTFE judges.jpg|thumb|The judges]]
+
+On January 19, 1946, MacArthur issued a special proclamation ordering the establishment of an International Military Tribunal for the Far East (IMTFE). On the same day, he also approved the [[Tokyo Charter|Charter of the International Military Tribunal for the Far East]] (CIMTFE), which prescribed how it was to be formed, the crimes that it was to consider, and how the tribunal was to function. The charter generally followed the model set by the [[Nuremberg Trials]]. On April 25, in accordance with the provisions of Article 7 of the CIMTFE, the original Rules of Procedure of the International Military Tribunal for the Far East with amendments were promulgated.<ref>{{cite web |url=http://www.yale.edu/lawweb/avalon/imtfech.htm|archiveurl=http://web.archive.org/web/19990222030537/http://www.yale.edu/lawweb/avalon/imtfech.htm |title=Charter of the International Military Tribunal for the Far East|accessdate=May 12, 2012|archivedate=February 22, 1999}}</ref><ref>Within documents relating to the IMTFE, it is also referred to as the "Charter".</ref><ref>Rules of Procedure of the International Military Tribunal for the Far East. April 25, 1946.</ref>
+
+===Judges===
+
+MacArthur appointed a panel of 12 judges, nine from the nations that signed the Instrument of Surrender.
+{| class="wikitable plainrowheaders"
+|-
+! scope="col" | Country
+! scope="col" | Judge
+! scope="col" | Background
+! scope="col" | Opinion
+|-
+! scope="row" | [[Australia]]
+| Sir [[William Webb (judge)|William Webb]]
+| Justice of the [[High Court of Australia]] <br /> President of the Tribunal
+| Separate
+|-
+! scope="row" | [[Canada]]
+| [[Edward Stuart McDougall]]
+| Justice of the [[Court of Appeal of Quebec|Court of King's Bench of Quebec]]
+|
+|-
+! scope="row" | [[Republic of China (1912-1949)|China]]
+| [[Mei Ju-ao]]
+| Attorney and Member of the [[Legislative Yuan]]
+|
+|-
+! scope="row" | [[Provisional Government of the French Republic|France]]
+| [[Henri Bernard]]
+| Avocat-General (Solicitor-General) at Bangui <br /> Chief Prosecutor, [[First Military Tribunal in Paris]]
+| Dissenting
+|-
+! scope="row" | [[India]]
+| [[Radhabinod Pal]]
+| Lecturer, [[University of Calcutta]] Law College <br /> Judge of the [[Calcutta High Court]]
+| Dissenting
+|-
+! scope="row" | [[Kingdom of the Netherlands|Netherlands]]
+| [[Professor]] [[Bert Röling]]
+| Professor of Law, [[Utrecht University]]
+| Dissenting
+|-
+! scope="row" | [[New Zealand]]
+| [[Erima Harvey Northcroft]]
+| Judge of the [[High Court of New Zealand|Supreme Court]] of New Zealand; former [[Judge Advocate General (New Zealand)|Judge Advocate General]] of the New Zealand Army
+|
+|-
+! scope="row" | [[Philippines]]
+| [[Colonel]] [[Delfin Jaranilla]]
+| [[Attorney General]] <br /> Associate Justice of the [[Supreme Court of the Philippines]]
+| Separate
+|-
+! scope="row" | United Kingdom
+| [[The Honourable]] [[William Donald Patrick|Lord Patrick]]
+| Judge (Scottish), [[Senator of the College of Justice]]
+|
+|-
+! scope="row" | United States
+| [[John P. Higgins]]
+| Chief Justice, [[Massachusetts]] [[Massachusetts Superior Court|Superior Court]]
+|
+|-
+! scope="row" | United States
+| [[Major-General]] Myron C. Cramer
+| [[Judge Advocate General's Corps|Judge Advocate General]] of the [[United States Army]] <br /> Replaced Judge Higgins in July 1946
+|
+|-
+! scope="row" | [[Soviet Union]]
+| [[Major-General]] [[I. M. Zaryanov]]
+| Member of the [[Military Collegium of the Supreme Court of the USSR]]
+|
+|}
+
+===Prosecutors===
+
+The chief prosecutor, [[Joseph B. Keenan]] of the United States, was appointed by President [[Harry S. Truman]].
+
+{| class="wikitable plainrowheaders"
+|-
+! scope="col" | Country
+! scope="col" | Prosecutor
+! scope="col" | Background
+|-
+! scope="row" | United States
+| Joseph Keenan
+| [[United States Assistant Attorney General|Assistant Attorney General of the United States]]<br> Director of the Criminal Division of the [[United States Department of Justice|Department of Justice of the United States]]
+|-
+! scope="row" | Australia
+| Mr. Justice [[Alan Mansfield]]
+| [[Puisne Justice|Senior Puisne Judge]] of the [[Supreme Court of Queensland]]
+|-
+! scope="row" | Canada
+| [[Brigadier]] [[Henry Nolan]]
+| Vice-Judge Advocate General of the [[Canadian Army]]
+|-
+! scope="row" | China
+| [[Hsiang Che-chun]]
+| Minister of Justice and Foreign Affairs
+|-
+! scope="row" | France
+| [[Robert L. Oneto]]
+|
+|-
+! scope="row" | India
+| [[P. Govinda Menon]]
+| Crown Prosecutor and Judge, Supreme Court of India
+|-
+! scope="row" | Netherlands
+| [[W.G. Frederick Borgerhoff-Mulder]]
+|
+|-
+! scope="row" | New Zealand
+| [[Brigadier]] [[Ronald Henry Quilliam]]
+| Deputy [[Adjutant-General]] of the [[New Zealand Army]]
+|-
+! scope="row" | Philippines
+| [[Pedro Lopez, prosecutor|Pedro Lopez]]
+| Associate Prosecutor of the Philippines
+|-
+! scope="row" | United Kingdom
+| [[Arthur Strettell Comyns Carr]]
+| British MP and Barrister
+|-
+! scope="row" | Soviet Union
+| [[Minister (diplomacy)|Minister]] and Judge [[Sergei Alexandrovich Golunsky]]
+|
+|}
+
+==Defendants==
+[[File:IMTFE defendants.jpg|thumb|The defendants]]
+
+Twenty-eight defendants were charged, mostly military officers and government officials.
+
+===Civilian officials===
+
+* [[Kōki Hirota]], prime minister (1936–1937), foreign minister (1933–1936, 1937–1938)
+* [[Kiichirō Hiranuma]], prime minister (1939), president of the privy council
+* [[Naoki Hoshino]], chief cabinet secretary
+* [[Kōichi Kido]], [[Lord Keeper of the Privy Seal of Japan|Lord Keeper of the Privy Seal]]
+* [[Toshio Shiratori]], Ambassador to Italy
+* [[Shigenori Tōgō]], foreign minister (1941–1942, 1945)
+* [[Mamoru Shigemitsu]], foreign minister (1943–1945)
+* [[Okinori Kaya]], finance minister (1941–1944)
+* [[Yōsuke Matsuoka]], foreign minister (1940–1941)
+
+===Military officers===
+
+* General [[Hideki Tōjō]], prime minister (1941–1944), war minister (1940–1944),chief of the [[Imperial Japanese Army General Staff Office]] (1944)
+* General [[Seishirō Itagaki]], war minister (1938-1939)
+* General [[Sadao Araki]], war minister (1931–1934)
+* Field Marshal [[Shunroku Hata]], war minister (1939–1940)
+* Admiral [[Shigetarō Shimada]], navy minister (1941–1944), chief of the [[Imperial Japanese Navy General Staff]] (1944)
+* Lieutenant General [[:ja:佐藤賢了|Kenryō Satō]], chief of the Military Affairs Bureau
+* General [[Kuniaki Koiso]], prime minister (1944–1945), governor-general of Korea (1942–1944)
+* Vice Admiral [[:ja:岡敬純|Takazumi Oka]], chief of the Bureau of Naval Affairs
+* Lieutenant General [[Hiroshi Ōshima]], ambassador to Germany
+* Fleet Admiral [[Nagano Osami]], navy minister (1936–1937), chief of the [[Imperial Japanese Navy General Staff]] (1941–1944)
+* General [[Jirō Minami]], governor-general of Korea (1936–1942)
+* General [[Kenji Doihara]], chief of the intelligence service in Manchukuo
+* General [[Heitarō Kimura]], commander of the Burma Area Army
+* General [[Iwane Matsui]], commander of the Shanghai Expeditionary Force and Central China Area Army
+* Lieutenant General [[Akira Mutō]], chief of staff of the 14th Area Army
+* Colonel [[Kingorō Hashimoto]], founder of [[Sakurakai]]
+* General [[Yoshijirō Umezu]], commander of the [[Kwantung Army]], chief of the [[Imperial Japanese Army General Staff Office]] (1944–1945)
+* Lieutenant General [[Teiichi Suzuki]], chief of the Cabinet Planning Board
+
+===Other defendants===
+
+* [[Shūmei Ōkawa]], a political philosopher
+
+==Tokyo War Crimes Trial==
+
+[[File:IMTFE court chamber.jpg|thumb|View of the Tribunal in session: the bench of judges is on the left, the defendants on the right, and the prosecutors in the back.]]
+
+Following months of preparation, the IMTFE convened on April 29, 1946. The trials were held in the War Ministry office in Tokyo.
+
+On May 3 the prosecution opened its case, charging the defendants with conventional war crimes, crimes against peace, and crimes against humanity. The trial continued for more than two and a half years, hearing testimony from 419 witnesses and admitting 4,336 exhibits of evidence, including depositions and affidavits from 779 other individuals.
+
+===Charges===
+
+Following the model used at the Nuremberg Trials in Germany, the Allies established three broad categories. "Class A" charges, alleging crimes against peace, were to be brought against Japan's top leaders who had planned and directed the war. Class B and C charges, which could be leveled at Japanese of any rank, covered conventional war crimes and crimes against humanity, respectively. Unlike the Nuremberg Trials, the charge of crimes against peace was a prerequisite to prosecution—only those individuals whose crimes included crimes against peace could be prosecuted by the Tribunal.
+
+The indictment accused the defendants of promoting a scheme of conquest that "contemplated and carried out...murdering, maiming and ill-treating [[prisoners of war]] (and) [[civilian internee]]s...[[Unfree labour|forcing them to labor]] under inhumane conditions...[[plunder]]ing [[public property|public]] and [[private property]], wantonly destroying [[cities]], [[town]]s and [[villages]] beyond any justification of [[military necessity]]; (perpetrating) [[mass murder]], [[War rape|rape]], pillage, [[brigandage]], [[torture]] and other barbaric cruelties upon the helpless [[civilian]] [[population]] of the over-run countries."
+
+Keenan issued a press statement along with the indictment: "War and treaty-breakers should be stripped of the glamour of national heroes and exposed as what they really are—plain, ordinary murderers".
+
+{| class="wikitable plainrowheaders"
+|-
+! scope="col" | Count
+! scope="col" | Offence
+|-
+! scope="row" |  1
+| As leaders, organisers, instigators, or accomplices in the formulation or execution of a common plan or conspiracy to wage wars of aggression, and war or wars in violation of international law
+|-
+! scope="row" | 27
+| Waging unprovoked war against China
+|-
+! scope="row" | 29
+| Waging aggressive war against the United States
+|-
+! scope="row" | 31
+| Waging aggressive war against the British Commonwealth (Crown colonies and protectorates of the United Kingdom in the Far East and South Asia, Australia and New Zealand)
+|-
+! scope="row" | 32
+| Waging aggressive war against the Netherlands (Dutch East Indies)
+|-
+! scope="row" | 33
+| Waging aggressive war against France (French Indochina)
+|-
+! scope="row" | 35, 36
+| Waging aggressive war against the USSR
+|-
+! scope="row" | 54
+| Ordered, authorised, and permitted inhumane treatment of prisoners of war and others
+|-
+! scope="row" | 55
+| Deliberately and recklessly disregarded their duty to take adequate steps to prevent atrocities
+|}
+
+===Evidence and testimony===
+
+The prosecution began opening statements on May 3, 1946, and took 192 days to present its case, finishing on January 24, 1947. It submitted its evidence in fifteen phases.
+
+The Charter provided that evidence against the accused could include any document "without proof of its issuance or signature" as well as diaries, letters, press reports, and sworn or unsworn out-of-court statements relating to the charges.{{sfn|Brackman|1987|p=60}} Article 13 of the Charter read, in part: "The tribunal shall not be bound by technical rules of evidence...and shall admit any evidence which it deems to have probative value".{{sfn|Minear|1971|p=118}}
+
+Wartime press releases of the Allies were admitted as evidence by the prosecution, while those sought to be entered by the defense were excluded. The recollection of a conversation with a long-dead man was admitted. Letters allegedly written by Japanese citizens were admitted with no proof of authenticity and no opportunity for cross examination by the defense.{{sfn|Minear|1971|p=120}}
+
+The Tribunal embraced the [[best evidence rule]] once the Prosecution had rested.{{sfn|Minear|1971|pp=122–123}} The best evidence rule dictates that the "best" or most authentic evidence must be produced (For example, a map instead of a description of the map; an original instead of a copy; and a witness instead of a description of what the witness may have said). Justice Pal, one of two justices to vote for acquittal on all counts, observed, "in a proceeding where we had to allow the prosecution to bring in any amount of hearsay evidence, it was somewhat misplaced caution to introduce this best evidence rule particularly when it operated practically against the defense only".{{sfn|Minear|1971|pp=122–123}}
+
+To prove their case, the prosecution team relied on the doctrine of "[[command responsibility]]". This doctrine was that it did not require proof of criminal orders. The prosecution had to prove three things: that war crimes were systematic or widespread; the accused knew that troops were committing atrocities; and the accused had power or authority to stop the crimes.
+
+The prosecution argued that a 1927 document known as the [[Tanaka Memorial]] showed that a "common plan or conspiracy" to commit "crimes against peace" bound the accused together. Thus, the prosecution argued that the conspiracy had begun in 1927 and continued through to the end of the war in 1945. The Tanaka Memorial is now considered by most historians to have been a forgery; however, it was not regarded as such at the time.
+
+===Defense===
+
+The defendants were represented by over a hundred attorneys, three-quarters of them Japanese and one-quarter American, plus a support staff. The defense opened its case on January 27, 1947, and finished its presentation 225 days later.
+
+The defense argued that the trial could never be free from substantial doubt as to its "legality, fairness and impartiality".<ref>George Furness, a Defense Counsel, stated, "[w]e say that regardless of the known integrity of the individual members of this tribunal they cannot, under the circumstances of their appointment, be impartial; that under the circumstances this trial, both in the present day and in history, will never be free from substantial doubt as to its legality, fairness and impartiality".</ref>
+
+The defense challenged the indictment, arguing that crimes against peace, and more specifically, the undefined concepts of conspiracy and aggressive war, had yet to be established as crimes in [[international law]]; in effect, the IMTFE was contradicting accepted legal procedure by trying the defendants retroactively for violating laws which had not existed when the alleged crimes had been committed. The defense insisted that there was no basis in international law for holding individuals responsible for acts of state, as the Tokyo Trial proposed to do. The defense attacked the notion of negative criminality, by which the defendants were to be tried for failing to prevent breaches of law and war crimes by others, as likewise having no basis in international law.
+
+The defense argued that Allied Powers' violations of international law should be examined.
+
+Former Foreign Minister [[Shigenori Tōgō]] maintained that Japan had had no choice but to enter the war for self-defense purposes. He asserted that "[because of the [[Hull Note]]] we felt at the time that Japan was being driven either to war or suicide".
+
+===Judgment===
+
+The IMT spent six months reaching judgment and drafting its 1,781-page opinion. On the day the judgment was read, five of the eleven justices released separate opinions outside the court.
+
+In his concurring opinion Justice [[William Webb (judge)|William Webb]] of Australia took issue with Emperor Hirohito's legal status, writing, "The suggestion that the Emperor was bound to act on advice is contrary to the evidence". While refraining from personal indictment of Hirohito, Webb indicated that Hirohito bore responsibility as a [[constitutional monarchy|constitutional monarch]] who accepted "ministerial and other advice for war" and that "no ruler can commit the crime of launching aggressive war and then validly claim to be excused for doing so because his life would otherwise have been in danger...It will remain that the men who advised the commission of a crime, if it be one, are in no worse position than the man who directs the crime be committed".{{sfn|Röling|Rüter|1977|p=478}}
+
+Justice [[Delfin Jaranilla]] of the Philippines disagreed with the penalties imposed by the tribunal as being "too lenient, not exemplary and deterrent, and not commensurate with the gravity of the offence or offences committed".
+
+Justice Henri Bernard of France argued that the tribunal's course of action was flawed due to Hirohito's absence and the lack of sufficient deliberation by the judges. He concluded that Japan's declaration of war "had a principal author who escaped all prosecution and of whom in any case the present Defendants could only be considered as accomplices",{{sfn|Röling|Rüter|1977|p=496}} and that a "verdict reached by a Tribunal after a defective procedure cannot be a valid one".
+
+"It is well-nigh impossible to define the concept of initiating or waging a war of aggression both accurately and comprehensively", wrote Justice Röling of the Netherlands in his dissent. He stated, "I think that not only should there have been neutrals in the court, but there should have been Japanese also." He argued that they would always have been a minority and therefore would not have been able to sway the balance of the trial. However, "they could have convincingly argued issues of government policy which were unfamiliar to the Allied justices". Pointing out the difficulties and limitations in holding individuals responsible for an act of state and making omission of responsibility a crime, Röling called for the acquittal of several defendants, including Hirota.
+
+[[Radhabinod_Pal|Justice Radhabinod Pal]] of India produced a 1,235-page judgment in which he dismissed the legitimacy of the IMTFE as [[victor's justice]]: "I would hold that each and every one of the accused must be found not guilty of each and every one of the charges in the indictment and should be acquitted on all those charges". While taking into account the influence of wartime propaganda, exaggerations, and distortions of facts in the evidence, and "over-zealous" and "hostile" witnesses, Pal concluded, "The evidence is still overwhelming that atrocities were perpetrated by the members of the Japanese armed forces against the civilian population of some of the territories occupied by them as also against the prisoners of war".
+
+===Sentencing===
+
+One defendant, [[Shūmei Ōkawa]], was found mentally unfit for trial and the charges were dropped.
+
+Two defendants, [[Matsuoka Yosuke]] and [[Nagano Osami]], died of natural causes during the trial.
+
+Six defendants were sentenced to death by hanging for war crimes, crimes against humanity, and crimes against peace (Class A, Class B and Class C):
+* General [[Kenji Doihara]], chief of the intelligence services in Manchukuo
+* [[Kōki Hirota]], prime minister (later foreign minister)
+* General [[Seishirō Itagaki]], war minister
+* General [[Heitarō Kimura]], commander, Burma Area Army
+* Lieutenant General [[Akira Mutō]], chief of staff, 14th Area Army
+* General [[Hideki Tōjō]], commander, Kwantung Army (later prime minister)
+One defendant was sentenced to death by hanging for war crimes and crimes against humanity (Class B and Class C):
+*General [[Iwane Matsui]], commander, Shanghai Expeditionary Force and Central China Area Army
+
+They were executed at [[Sugamo Prison]] in [[Ikebukuro]] on December 23, 1948. MacArthur, afraid of embarrassing and antagonizing the Japanese people, defied the wishes of President Truman and barred photography of any kind, instead bringing in four members of the Allied Council to act as official witnesses.
+
+Sixteen defendants were sentenced to life imprisonment. Three (Koiso, Shiratori, and Umezu) died in prison, while the other thirteen were [[parole]]d between 1954 and 1956:
+* General [[Sadao Araki]], war minister
+* Colonel [[Kingorō Hashimoto]], major instigator of the [[second Sino-Japanese War]]
+* Field Marshal [[Shunroku Hata]], war minister
+* Baron [[Kiichirō Hiranuma]], prime minister
+* [[Naoki Hoshino]], Chief Cabinet Secretary
+* [[Okinori Kaya]], finance minister
+* Marquis [[Kōichi Kido]], [[Lord Keeper of the Privy Seal of Japan|Lord Keeper of the Privy Seal]]
+* General [[Kuniaki Koiso]], governor of Korea, later prime minister
+* General [[Jirō Minami]], commander, Kwantung Army
+* Admiral [[:ja:岡敬純|Takazumi Oka]], naval minister
+* Lieutenant General [[Hiroshi Ōshima]], Ambassador to Germany
+* General [[:ja:佐藤賢了|Kenryō Satō]], chief of the Military Affairs Bureau
+* Admiral [[Shigetarō Shimada]], naval minister
+* [[Toshio Shiratori]], Ambassador to Italy
+* Lieutenant General [[Teiichi Suzuki]], president of the Cabinet Planning Board
+* General [[Yoshijirō Umezu]], war minister
+
+Foreign minister [[Shigenori Tōgō]] was sentenced to 20 years imprisonment and died in prison in 1949. Foreign minister [[Mamoru Shigemitsu]] was sentenced to 7 years.
+
+The verdict and sentences of the tribunal were confirmed by MacArthur on November 24, 1948, two days after a perfunctory meeting with members of the [[Allied Commission#Japan|Allied Control Commission for Japan]], who acted as the local representatives of the nations of the Far Eastern Commission. Six of those representatives made no recommendations for clemency. Australia, Canada, India, and the Netherlands were willing to see the general make some reductions in sentences. He chose not to do so. The issue of clemency was thereafter to disturb Japanese relations with the Allied powers until the late 1950s, when a majority of the Allied powers agreed to release the last of the convicted major war criminals from captivity.
+
+==Criticism==
+
+According to Japanese records, 5,700 Japanese individuals were indicted for Class B and Class C war crimes. Of this number, 984 were initially condemned to death; 475 received life sentences; 2,944 were given more limited prison terms; 1,018 were acquitted; and 279 were never brought to trial or not sentenced. The number of death sentences by country is as follows: the Netherlands 236, Great Britain 223, Australia 153, China 149, United States 140, France 26, and Philippines 17.{{sfn|Dower|1999|p=447}} The Soviet Union and Chinese Communist forces also held trials for Japanese war criminals.
+
+The [[Khabarovsk War Crime Trials]] held by the Soviets tried and found guilty some members of Japan's bacteriological and chemical warfare unit, also known as [[Unit 731]]. However, those who surrendered to the Americans were never brought to trial. As [[Supreme Commander of the Allied Powers]], MacArthur gave [[immunity from prosecution (international law)|immunity]] to [[Shiro Ishii]] and all members of the bacteriological research units in exchange for germ warfare data based on [[human experimentation]]. On May 6, 1947, he wrote to Washington that "additional data, possibly some statements from Ishii probably can be obtained by informing Japanese involved that information will be retained in intelligence channels and will not be employed as 'War Crimes' evidence".{{sfn|Gold|2003|p=109}} The deal was concluded in 1948.<ref name="commondreams.org">{{cite web |url= http://www.commondreams.org/views05/0510-24.htm |title=An Ethical Blank Check: British and US Mythology About the Second World War Ignores Our Own Crimes and Legitimizes Anglo-American Warmaking |first=Richard |last=Drayton | work = [[The Guardian]] |date=May 10, 2005 |accessdate=May 9, 2012}}</ref>
+
+In 1981 [[John W. Powell]] published an article in the ''[[Bulletin of the Atomic Scientists]]'' detailing the experiments of [[Unit 731]] and its open-air tests of germ warfare on civilians. It was printed with a statement by Judge Röling, the last surviving member of the Tokyo Tribunal, who wrote, "As one of the judges in the International Military Tribunal, it is a bitter experience for me to be informed now that centrally ordered Japanese war criminality of the most disgusting kind was kept secret from the Court by the U.S. government".<ref>{{cite book|last=Barenblatt|first=Daniel|title=A Plague upon Humanity|publisher= Harper Collins|year= 2004| page=222}}</ref>
+
+===Charges of victors' justice===
+
+The United States had provided the funds and staff necessary for running the Tribunal and also held the function of Chief Prosecutor. The argument was made that it was difficult, if not impossible, to uphold the requirement of impartiality with which such an organ should be invested. This apparent conflict gave the impression that the tribunal was no more than a means for the dispensation of victor's justice. Solis Horowitz argues that IMTFE had an American bias: unlike the [[Nuremberg Trials]], there was only a single prosecution team, led by an American, although the members of the tribunal represented eleven different Allied countries.{{sfn|Horowitz|1950}} The IMTFE had less official support than the Nuremberg Trials. Keenan, a former U.S. assistant attorney general, had a much lower position than Nuremberg's [[Robert H. Jackson]], a justice of the [[Supreme Court of the United States|U.S. Supreme Court]].
+
+Justice Delfin had been captured by the Japanese and walked the [[Bataan Death March]].<ref>
+{{cite web
+| url= http://www.osg.gov.ph/index.php/-assistant-sollicitors-general/fsolgens/112-delfin-j-jaranilla
+| title= Hon. Delfin J. Jaranilla, Attorney General, 1927 - 1932
+| publisher = Republic Of The Philippines, Office Of The Solicitor General
+| accessdate= 29 April 2013
+}}</ref> The defense sought to remove him from the bench claiming he would be unable to maintain objectivity. The request was rejected but Delfin did excuse himself from presentation of evidence for atrocities in his native country of the Philippines.<ref>{{cite book
+ | title =Documents on the Tokyo International Military Tribunal: Charter, Indictment, and Judgments, Volume 1
+ | editor = Robert Cryer, Neil Boister
+ | publisher =Oxford University Press
+ | volume =1
+ | date =Sep 25, 2008
+ | pages = LV
+ | url =http://books.google.com/books?id=rHainkH7pdEC&lpg=PR55&ots=KtGtPeDbaP&dq=Delfin%20Jaranilla&pg=PR55#v=onepage&q=Delfin%20Jaranilla&f=false
+ | isbn =0199541922 }}
+</ref>
+
+Justice Radhabinod Pal argued that the exclusion of Western colonialism and the [[atomic bombings of Hiroshima and Nagasaki|use of the atomic bomb]] by the United States from the list of crimes and the lack of judges from the vanquished nations on the bench signified the "failure of the Tribunal to provide anything other than the opportunity for the victors to retaliate".<ref name="brook">"The Tokyo Judgment and the Rape of Nanking", by [[Timothy Brook (historian)|Timothy Brook]], ''The Journal of Asian Studies'', August 2001.</ref> In this he was not alone among Indian jurists, with one prominent Calcutta barrister writing that the Tribunal was little more than "a sword in a [judge's] wig".
+
+Justice Röling stated, "[o]f course, in Japan we were all aware of the [[Bombing of Tokyo|bombings and the burnings of Tokyo]] and [[Yokohama]] and [[Air raids on Japan|other big cities]]. It was horrible that we went there for the purpose of vindicating the laws of war, and yet saw every day how the Allies had violated them dreadfully". However, no [[Positive international law|positive]] or specific [[Customary international law|customary]] [[international humanitarian law]] with respect to [[aerial warfare]] existed before and during World War II, which was one of the main reasons why Japanese officers escaped prosecution for their aerial raids on cities in China and other nations in Asia.<ref>{{cite book |title=Terror from the Sky: The Bombing of German Cities in World War II |year=2010 |page=167 |publisher=[[Berghahn Books]] |isbn=1-8454-5844-3}}</ref>
+
+===Pal's dissenting opinion===
+
+Pal's dissenting opinion raised substantive objections: he found that the entire prosecution case to be weak regarding the conspiracy to commit an act of aggressive war, which would include the brutalization and subjugation of conquered nations. About the [[Nanking Massacre]]—while acknowledging the brutality of the incident—he said that there was nothing to show that it was the "product of government policy" or that Japanese government officials were directly responsible. There is "no evidence, testimonial or circumstantial, concomitant, prospectant, restrospectant, that would in any way lead to the inference that the government in any way permitted the commission of such offenses", he said.<ref name="brook"/> In any case, he added, conspiracy to wage aggressive war was not illegal in 1937, or at any point since.<ref name="brook"/>
+
+===Exoneration of the imperial family===
+
+There has been much criticism of the blanket exoneration of [[Hirohito|Emperor Hirohito]] and all members of the imperial family, including [[Prince Asaka]], [[Prince Fushimi Hiroyasu]], [[Prince Higashikuni]] and [[Prince Tsuneyoshi Takeda|Prince Takeda]].{{sfn|Dower|1999|p= }}{{sfn|Bix|2001|p= }}
+
+As early as November 26, 1945, MacArthur confirmed to Admiral [[Mitsumasa Yonai]] that the emperor's abdication would not be necessary.{{sfn|Dower|1999|pp=323–325}} Before the war crimes trials actually convened, SCAP, the IPS, and court officials worked behind the scenes not only to prevent the imperial family from being indicted, but also to slant the testimony of the defendants to ensure that no one implicated the emperor. High officials in court circles and the Japanese government collaborated with Allied GHQ in compiling lists of prospective war criminals. People arrested as Class A suspects and incarcerated in the [[Sugamo Prison]] solemnly vowed to protect their sovereign against any possible taint of war responsibility.{{sfn|Dower|1999|pp=323–325}}
+
+According to historian [[Herbert Bix]], Brigadier General [[Bonner Fellers]] "immediately on landing in Japan went to work to protect Hirohito from the role he had played during and at the end of the war" and "allowed the major criminal suspects to coordinate their stories so that the emperor would be spared from indictment".{{sfn|Bix|2001|p=583}}
+
+Bix also argues that "MacArthur's truly extraordinary measures to save Hirohito from trial as a war criminal had a lasting and profoundly distorting impact on Japanese understanding of the lost war" and "months before the Tokyo tribunal commenced, MacArthur's highest subordinates were working to attribute ultimate responsibility for [[Pearl Harbor attack|Pearl Harbor]] to [[Hideki Tojo|Hideki Tōjō]]".{{sfn|Bix|2001|p=585}} According to a written report by Shūichi Mizota, Admiral [[Mitsumasa Yonai]]'s interpreter, Fellers met the two men at his office on March 6, 1946, and told Yonai, "it would be most convenient if the Japanese side could prove to us that the emperor is completely blameless. I think the forthcoming trials offer the best opportunity to do that. Tōjō, in particular, should be made to bear all responsibility at this trial".<ref>Kumao Toyoda, ''Sensô saiban yoroku'', Taiseisha Kabushiki Kaisha, 1986, p.170–172.</ref>{{sfn|Bix|2001|p=584}}
+
+Historian [[John W. Dower]] wrote that the campaign to absolve Emperor Hirohito of responsibility "knew no bounds". He argued that with MacArthur's full approval, the prosecution effectively acted as "a defense team for the emperor", who was presented as "an almost saintly figure" let alone someone culpable of war crimes.{{sfn|Dower|1999|pp=323–325}} He stated, "Even Japanese activists who endorse the ideals of the Nuremberg and Tokyo charters, and who have labored to document and publicize the atrocities of the Shōwa regime, cannot defend the American decision to exonerate the emperor of war responsibility and then, in the chill of the [[Cold War]], release and soon afterwards openly embrace accused right-winged war criminals like the later prime minister [[Nobusuke Kishi]]".{{sfn|Dower|1999|p=562}}
+
+Three justices wrote an ''[[obiter dictum]]'' about the criminal responsibility of Hirohito. Judge-in-Chief Webb declared, "no ruler can commit the crime of launching aggressive war and then validly claim to be excused for doing so because his life would otherwise have been in danger...It will remain that the men who advised the commission of a crime, if it be one, are in no worse position than the man who directs the crime be committed".{{sfn|Röling|Rüter|1977|p=478}}
+
+Justice Henri Bernard of France concluded that Japan's declaration of war "had a principal author who escaped all prosecution and of whom in any case the present Defendants could only be considered as accomplices".{{sfn|Röling|Rüter|1977|p=496}}
+
+Justice Röling did not find the emperor's immunity objectionable and further argued that five defendants (Kido, Hata, Hirota, Shigemitsu, and Tōgō) should have been acquitted.
+
+==Aftermath==
+
+===Release of the remaining 42 "Class A" suspects===
+
+The International Prosecution Section of the SCAP decided to try the seventy Japanese apprehended for "Class A" war crimes in three groups. The first group of 28 were major leaders in the military, political, and diplomatic sphere. The second group (23 people) and the third group (nineteen people) were industrial and financial magnates who had been engaged in weapons manufacturing industries or were accused of trafficking in narcotics, as well as a number of lesser known leaders in military, political, and diplomatic spheres. The most notable among these were:
+
+* [[Nobusuke Kishi]]: In charge of industry and commerce of Manchukuo, 1936–40; Minister of Industry and Commerce under Tojo administration
+* [[Fusanosuke Kuhara]]: Leader of the pro-[[Zaibatsu]] faction of [[Rikken Seiyukai]]
+* [[Yoshisuke Ayukawa]]: Sworn brother of Fusanosuke Kuhara, founder of Japan Industrial Corporation; went to Manchuria after the [[Mukden Incident]] (1931), where he founded the [[Manchurian Heavy Industry Development Company]]
+* [[Toshizō Nishio]]: Chief of Staff of the Kwantung Army, Commander-in-Chief of China Expeditionary Army, 1939–41; war-time Minister of Education
+* [[Kichiburo Ando]]: Garrison Commander of Port Arthur and Minister of Interior in the Tojo cabinet
+* [[Yoshio Kodama]]: a radical ultranationalist
+* [[Kazuo Aoki]]: Administrator of Manchurian affairs; Minister of Treasury in Nobuyoki Abe's cabinet; followed Abe to China as an advisor; [[Ministry of Greater East Asia|Minister of Greater East Asia]] in the Tojo cabinet
+* [[Masayuki Tani]]: Ambassador to Manchukuo, Minister of Foreign Affairs and concurrently Director of the Intelligence Bureau; Ambassador to the [[Reorganized National Government of China]]
+* [[Eiji Amo]]: Chief of the Intelligence Section of Ministry of Foreign Affairs; Deputy Minister of Foreign Affairs; Director of Intelligence Bureau in the Tojo cabinet
+* [[Yakijiro Suma]]: Consul General at Nanking; in 1938, he served as counselor at the Japanese Embassy in Washington; after 1941, Minister Plenipotentiary to Spain
+* [[Ryoichi Sasakawa]]: Ultranationalist businessman and philanthropist
+
+All remaining people apprehended and accused of Class A war crimes who had not yet come to trial were set free by MacArthur in 1947 and 1948.
+
+===San Francisco Peace Treaty===
+
+Under Article 11 of the [[Treaty of San Francisco|San Francisco Peace Treaty]], signed on September 8, 1951, Japan accepted the jurisdiction of the International Military Tribunal for the Far East. Article 11 of the treaty reads:
+
+{{quote | Japan accepts the judgments of the International Military Tribunal for the Far East and of other Allied War Crimes Courts both within and outside Japan, and will carry out the sentences imposed thereby upon Japanese nationals imprisoned in Japan. The power to grant clemency, reduce sentences and parole with respect to such prisoners may not be exercised except on the decision of the government or governments which imposed the sentence in each instance, and on the recommendation of Japan. In the case of persons sentenced by the International Military Tribunal for the Far East, such power may not be exercised except on the decision of a majority of the governments represented on the Tribunal, and on the recommendation of Japan.<ref>{{cite web |url=http://www.taiwandocuments.org/sanfrancisco01.htm |title=Taiwan Documents Project – Treaty of Peace with Japan |accessdate=April 13, 2009}}</ref>}}
+
+===Parole for war criminals movement===
+
+In 1950, after most Allied war crimes trials had ended, thousands of convicted war criminals sat in prisons across Asia and Europe, detained in the countries where they had been convicted. Some executions had not yet been carried out, as Allied courts agreed to reexamine their verdicts. Sentences were reduced in some cases, and a system of parole was instituted, but without relinquishing control over the fate of the imprisoned (even after Japan and Germany had regained their sovereignty).
+
+The focus changed from the top wartime leaders to "ordinary" war criminals (Class B and C in Japan), and an intense and broadly-supported campaign for amnesty for all imprisoned war criminals ensued. The issue of criminal responsibility was reframed as a humanitarian problem.
+
+On March 7, 1950, MacArthur issued a directive that reduced the sentences by one-third for good behavior and authorized the parole after fifteen years of those who had received life sentences. Several of those who were imprisoned were released earlier on parole due to ill health.
+
+Many Japanese reacted to the Tokyo War Crimes Tribunal by demanding parole for the detainees or mitigation of their sentences. Shortly after the San Francisco Peace Treaty came into effect, a movement demanding the release of B- and C-class war criminals began, emphasizing the "unfairness of the war crimes tribunals" and the "misery and hardship of the families of war criminals". The movement quickly garnered the support of more than ten million Japanese. The government commented that "public sentiment in our country is that the war criminals are not criminals. Rather, they gather great sympathy as victims of the war, and the number of people concerned about the war crimes tribunal system itself is steadily increasing".
+
+The parole for war criminals movement was driven by two groups: people who had "a sense of pity" for the prisoners demanded, "just set them free" (''tonikaku shakuho o'') regardless of how it is done. The war criminals themselves called for their own release as part of an anti-war peace movement.
+
+On September 4, 1952, President Truman issued Executive Order 10393, establishing a Clemency and Parole Board for War Criminals. Its purpose was to advise the President regarding recommendations by the Government of Japan for clemency, reduction of sentence, or parole of Japanese war criminals sentenced by military tribunals.<ref>{{cite web |url=http://www.presidency.ucsb.edu/ws/index.php?pid=78495 |title=Harry S. Truman – Executive Order 10393 – Establishment of the Clemency and Parole Board for War Criminals |accessdate=April 13, 2009}}</ref>
+
+On May 26, 1954, Secretary of State [[John Foster Dulles]] rejected a proposed amnesty for the imprisoned war criminals but instead agreed to "change the ground rules" by reducing the period required for eligibility for parole from 15 years to 10 years.<ref>{{cite book |title=Law and War |first=Peter H. |last=Maguire |page=255  |publisher=Columbia University Press |isbn=978-0-231-12051-7 |year=2000}}</ref>
+
+By the end of 1958, all Japanese war criminals were released from prison and politically rehabilitated. Hashimoto Kingorô, Hata Shunroku, Minami Jirô, and Oka Takazumi were all released on parole in 1954. Araki Sadao, Hiranuma Kiichirô, Hoshino Naoki, Kaya Okinori, Kido Kôichi, Ôshima Hiroshi, Shimada Shigetarô, and Suzuki Teiichi were released on parole in 1955. Satô Kenryô, whom many—including Judge Röling—regarded as the one least deserving of imprisonment, was not granted parole until March 1956, the last of the Class A Japanese war criminals to be released. With the concurrence of a majority of the powers represented on the tribunal, the Japanese government announced on April 7, 1957, that the last ten major Japanese war criminals who had previously been paroled were granted clemency and were to be regarded henceforth as unconditionally free.
+
+==Legacy==
+
+In 1978 the ''[[kami]]'' of 1,068 convicted war criminals, including 14 convicted Class-A war criminals were secretly enshrined at [[Yasukuni Shrine]].<ref name="CNN">{{cite web|url=http://edition.cnn.com/2001/WORLD/asiapcf/east/08/13/japan.shrine/ |title=Where war criminals are venerated |accessdate=April 13, 2008 |date=January 4, 2003 |work=[[CNN.com]]}}</ref> Those enshrined include Hideki Tōjō, Kenji Doihara, Iwane Matsui, Heitarō Kimura, Kōki Hirota, Seishirō Itagaki, Akira Mutō, Yosuke Matsuoka, Osami Nagano, Toshio Shiratori, Hiranuma Kiichirō, Kuniaki Koiso and Yoshijirō Umezu.<ref>{{cite web|url=http://japanfocus.org/products/topdf/2443|archiveurl= http://web.archive.org/web/20071016212351/http://japanfocus.org/products/topdf/2443|title=Enshrinement Politics: War Dead and War Criminals at Yasukuni Shrine|publisher=JapanFocus |date= |accessdate=May 12, 2012|archivedate=October 16, 2007}}</ref> Since 1985, visits made by Japanese government officials to the Shrine have aroused protests in China and South Korea.
+
+[[Arnold Brackman]], who had covered the trials for [[United Press International]], wrote ''The Other Nuremberg:  The Untold Story of the Tokyo War Crimes Trial'', a rebuttal to charges that the trial had been "victors' justice;" this rebuttal was published posthumously in 1987.<ref>Brackman, Arnold C. (1987), ''The Other Nuremberg:  The Untold Story of the Tokyo War Crimes Trial'', New York:  Morrow.</ref>
+
+In a survey of 3,000 Japanese people conducted by [[Asahi Newspaper|''Asahi News'']] as the 60th anniversary approached in 2006, 70% of those questioned were unaware of the details of the trials, a figure that rose to 90% for those in the 20–29 age group. Some 76% of the people polled recognized a degree of aggression on Japan's part during the war, while only 7% believed it was a war strictly for self-defense.<ref>{{cite web|url=http://www.mansfieldfdn.org/polls/poll-06-3.htm|archiveurl=http://web.archive.org/web/20061108001700/http://www.mansfieldfdn.org/polls/poll-06-3.htm|title=''Asahi Shimbun'' May 2, 2006 "Tokyo Trials Poll"|date=April 2006|publisher=Mansfield Asian Opinion Poll Database |accessdate=May 9, 2012|archivedate=November 8, 2006}}</ref>
+
+A South Korean government commission cleared 83 of the 148 Koreans convicted by the Allies of war crimes during World War II. The commission ruled that the Koreans, who were categorized as Class B and Class C war criminals, were in fact victims of Japanese imperialism.<ref>{{cite web |url= http://www.rjkoehler.com/2006/11/13/korean-war-criminals-cleared/ |title=Korean war criminals cleared |first=Robert |last=Koehler |work=rjkoehler.com |date=November 13, 2006 |accessdate=May 9, 2012}}</ref>
+
+==See also==
+{{div col|colwidth=30em}}
+* [[INA trials]]
+* [[Japanese war crimes]]
+* [[Justice Erima Harvey Northcroft Tokyo War Crimes Trial Collection]]
+* [[Nanjing War Crimes Tribunal]]
+* [[Nanking Massacre]]
+* [[Nanking (2007 film)|''Nanking'' (film)]]: A 2007 Chinese film about Nanking Massacre.
+* [[Tokyo Trial (film)|''Tokyo Trial'' (film)]]: A 2006 Chinese film about the trial.
+* [[Pride (1998 film)|プライド運命の瞬間 ("Praido", Pride)]]: A 1998 Japanese film about the trial.
+{{div col end}}
+
+==References==
+
+===Notes===
+{{Reflist|20em}}
+
+===Books===
+* {{cite book
+ | last = Bix
+ | first = Herbert
+ | authorlink = Herbert Bix
+ | year = 2001
+ | title = [[Hirohito and the Making of Modern Japan]]
+ | publisher = Perennial
+ | ref = harv
+}}
+* {{cite book
+ | last = Brackman
+ | first = Arnold C.
+ | title = The Other Nuremberg: The Untold Story of the Tokyo War Crimes Trial
+ | year = 1987
+ | publisher = William Morrow and Company
+ | location = New York
+ | isbn =
+ | ref = harv
+}}
+* Byas, Hugh (1942).  ''Government by Assassination''.  New York:  Knopf.
+* {{cite book
+ | last = Dower
+ | first = John
+ | authorlink = John W. Dower
+ | title = [[Embracing Defeat]]
+ | year = 1999
+ | ref = harv
+}}
+* {{cite book
+ | last = Gold
+ | first = Hal
+ | title = Unit 731: Testimony
+ | year = 2003
+ | publisher = Tuttle
+ | location =
+ | isbn =
+ | ref = harv
+}}
+* {{cite journal
+ | last = Horowitz
+ | first = Solis
+ | title = The Tokyo Trial
+ | journal = International Conciliation
+ | year = 1950
+ | volume = 465
+ | issue = November
+ | pages = 473–584
+ | ref = harv
+}}
+* {{cite book
+ | last = Minear
+ | first = Richard H.
+ | authorlink = Richard Minear
+ | coauthors =
+ | year = 1971
+ | chapter =
+ | title = Victor's Justice: The Tokyo War Crimes Trial
+ | publisher = Princeton University Press
+ | location = Princeton, New Jersey
+ | ref = harv
+}}
+* {{cite book
+ | last1 = Röling
+ | first1 = B. V. A.
+ | last2 = Rüter
+ | first2 = C. F.
+ | title = The Tokyo Judgment: The International Military Tribunal for the Far East (I.M.T.F.E), 29 April 1946-12 November 1948
+ | volume = 1
+ | year = 1977
+ | publisher = APA-University Press
+ | location = Amsterdam
+ | isbn = 978-90-6042-041-6
+ | ref = harv
+}}
+
+===Web===
+
+*{{cite web
+ | last = International Military Tribunal for the Far East
+ | first =
+ | year =
+ | url = http://www.ibiblio.org/hyperwar/PTO/IMTFE/index.html
+ | title = Judgment: International Military Tribunal for the Far East
+ | work =
+ | accessdate =March 29, 2006
+}}
+* {{cite web
+ | author = Ming-Hui Yao
+ | title = Nanjing Massacre and the Tokyo War Crimes Trial
+ | work = archives.cnd.org
+}}
+
+==Further reading==
+{{refbegin|30em}}
+*{{cite book|author1=International Military Tribunal for the Far East|author2=R. John Pritchard|title=The Tokyo major war crimes trial: the transcripts of the court proceedings of the International Military Tribunal for the Far East|publisher=Robert M.W. Kempner Collegium by E. Mellen Press|isbn=978-0-7734-8313-2}}
+* {{cite book
+ | last = Bass
+ | first = Gary Jonathan
+ | title = Stay the Hand of Vengeance: The Politics of War Crimes Trials
+ | year = 2000
+ | publisher = Princeton University Press
+ | location = Princeton, New Jersey }}
+* {{cite book
+ | last = Frank
+ | first = Richard B.
+ | authorlink = Richard B. Frank
+ | year = 1999
+ | title = Downfall: The End of the Imperial Japanese Empire
+ | publisher = Penguin Books
+ | location = New York}}
+* {{cite book
+ | last = Holmes
+ | first = Linda Goetz
+ | year = 2001
+ | chapter =
+ | title = Unjust Enrichment: How Japan's Companies Built Postwar Fortunes Using American POWs
+ | publisher = Stackpole Books
+ | location = Mechanicsburg, Pennsylvania}}
+* {{cite book
+ | last = Lael
+ | first = Richard L.
+ | year = 1982
+ | title = The Yamashita Precedent: War Crimes and Command Responsibility
+ | publisher = Scholarly Resources
+ | location = Wilmington, Delaware
+}}
+* {{cite book
+ | last = Maga
+ | first = Timothy P.
+ | year = 2001
+ | title = Judgment at Tokyo: The Japanese War Crimes Trials
+ | publisher = University Press of Kentucky
+ | location = Lexington
+ | isbn = 978-0-8131-2177-2}}
+* {{cite book
+ | last = Piccigallo
+ | first = Philip R.
+ | year = 1979
+ | title = The Japanese on Trial: Allied War Crimes Operations in the East, 1945–1951
+ | publisher = University of Texas Press
+ | location = Austin, Texas}}
+* {{cite book
+ | last = Rees
+ | first = Laurence
+ | year = 2001
+ | title = Horror in the East: Japan and the Atrocities of World War II
+ | publisher = Da Capo Press
+ | location = Boston}}
+* {{cite book
+ | last = Sherman
+ | first = Christine
+ | year = 2001
+ | chapter =
+ | title = War Crimes: International Military Tribunal
+ | publisher = Turner Publishing Company
+ | location = Paducah, Kentucky
+ | isbn = 978-1-56311-728-2}}
+* {{cite book
+ | last = Totani
+ | first = Yuma
+ | authorlink =
+ | coauthors =
+ | year = 2009
+ | chapter =
+ | title = The Tokyo War Crimes Trial: The Pursuit of Justice in the Wake of World War II
+ | publisher = Harvard University Asia Center
+ | location = Cambridge
+ | isbn = 978-0-674-03339-9}}
+{{refend}}
+
+==External links==
+*[http://law.emory.edu/eilr/_documents/volumes/27/2/symposium/kaufman.pdf Zachary D. Kaufman, "Transitional Justice for Tojo's Japan: the United States Role in the Establishment of the International Military Tribunal for the Far East and Other Transitional Justice Mechanisms for Japan after World War II" ''Emory International Law Review'', vol. 27 (2013)]
+*[http://www.cardozolawreview.com/content/27-4/ZHANG.WEBSITE.pdf Zhang Wanhong, "From Nuremberg to Tokyo: Some Reflections on the Tokyo Trial" ''Cardozo Law Review'', vol. 27 (2006)]
+*{{Commons category-inline}}
+
+{{World War II}}
+{{JapanEmpireNavbox}}
+{{International Criminal Law}}
+
+{{DEFAULTSORT:International Military Tribunal For The Far East}}
+[[Category:International Military Tribunal for the Far East| ]]
+[[Category:Crimes against humanity]]
+[[Category:Crime of aggression]]
+[[Category:Wartime sexual violence in World War II]]


### PR DESCRIPTION
Many annotations take place in tables like in [1] or Lists like in [2].

- This PR considers each row of the table as a `paragraphWithLinks`.  
- This PR considers each item in the list as a `paragraphWithLinks`. . (this includes the section : `See also` at the bottom of articles)
- In both cases we extract the text with correct anchors (matching spans in text)

while doing this spotted: https://github.com/idio/json-wikipedia/issues/7 so two of the links in [2] wont be caught by this PR.

[1] https://en.wikipedia.org/wiki/International_Military_Tribunal_for_the_Far_East
[2] https://en.wikipedia.org/wiki/Hayami