### PR TITLE
Fix - plus chars being unquoted as spaces

### DIFF
--- a/src/main/java/it/cnr/isti/hpc/wikipedia/article/Link.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/article/Link.java
@@ -38,7 +38,7 @@ public class Link {
 	public Link(String id, String anchor, int start, int end) {
 		super();
 		try {
-			this.id = java.net.URLDecoder.decode(id, "UTF-8");
+			this.id = java.net.URLDecoder.decode(id.replace("+", "%2B"), "UTF-8");
 		} catch(Exception e) {
 			this.id = id;
 		}

--- a/src/test/java/it/cnr/isti/hpc/wikipedia/article/it/ItalianArticleTest.java
+++ b/src/test/java/it/cnr/isti/hpc/wikipedia/article/it/ItalianArticleTest.java
@@ -118,8 +118,8 @@ public class ItalianArticleTest extends ArticleTest {
 		Pair<List<String>, List<String>> anchorsAndUris = getAnchorsAndUris(a);
 		List<String> anchors = anchorsAndUris.getFirst();
 		List<String> uris = anchorsAndUris.getSecond();
-		assertThat(uris, hasItems("Harry_Potter", "Sōtō", "Arashiyama", "Kyoto", "Università_degli_Studi_di_Napoli_Federico_II", "Lo_Hobbit_(trilogia)", "Laaber_Straße", "100%Magazine"));
-		assert(uris.size()==10);
+		assertThat(uris, hasItems("Harry_Potter", "Sōtō", "Arashiyama", "Kyoto", "Università_degli_Studi_di_Napoli_Federico_II", "Lo_Hobbit_(trilogia)", "Laaber_Straße", "100%Magazine", "1+2+3"));
+		assert(uris.size()==11);
 
 		assertFalse(uris.contains("File:Yukipon_SxH1.jpg"));
 		assertFalse(uris.contains("File:Nunz2.JPG"));

--- a/src/test/resources/it/xml-dump/article_with_weird_annotations
+++ b/src/test/resources/it/xml-dump/article_with_weird_annotations
@@ -41,3 +41,4 @@ something something [[File:Yukipon SxH1.jpg|thumb|left|Immagine di un doujinshi 
 something something[[Immagine:Japanese buddhist monk by Arashiyama cut.jpg|thumb|upright=1.4|Monaco Zen di scuola [[Sōtō]] ad [[Arashiyama]], [[Kyoto]] nella classica postura dello ''zazen''.]]
 something something [[File:Nunz2.JPG|thumb|left|[[Scuola militare &quot;Nunziatella&quot;|Complesso della Nunziatella]], prima [[Accademie e scuole militari in Italia#Scuole superiori militari|scuola militare]] al mondo tra quelle ancora operative senza soluzione di continuità]]
 something something  [[File:Federico II Napoli giurisprudenza (panoramica).jpg|thumb|Sede della facoltà di Giurisprudenza alla [[Università degli Studi di Napoli Federico II|Federico II]]]]
+something something [[1+2+3]]


### PR DESCRIPTION
Connected to idio/json-wikipedia#36
Connected to idio/content-services#695

Almost all of the missing dbpedia_rels in the new ontology (that are in the old one) are identifiers that have a +.

Java URLDecoder.decode transform + into spaces, apperantly this is the cause of the evil.