### PR TITLE
Upgrading to spark 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk7
+- openjdk7
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,9 @@
             <version>3.1.1</version>
         </dependency>
         <dependency>
-            <groupId>com.github.idio</groupId>
             <artifactId>hpc-utils</artifactId>
+            <groupId>it.cnr.isti.hpc</groupId>
             <version>0.0.7</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-core</artifactId>
-            <version>4.3.0</version>
         </dependency>
         <dependency>
             <groupId>xerces</groupId>
@@ -80,13 +75,13 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.10</artifactId>
-            <version>1.3.1</version>
+            <artifactId>spark-core_2.11</artifactId>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.10.4</version>
+            <version>2.11.8</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -171,11 +166,16 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>dropbox</id>
+            <url>https://dl.dropboxusercontent.com/u/4663256/mvn-repository/</url>
+        </repository>
     </repositories>
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
                 <configuration>
                     <charset>${project.source.charset}</charset>
                     <encoding>${project.source.encoding}</encoding>
@@ -205,6 +205,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>scala-compile-first</id>


### PR DESCRIPTION
Since we are upgrading spark in rendang for version 2, it would be nice to move all our apps to that as well.

In this PR we do:
- upgrade to spark 2
- upgrade scala
- use hpc-utils from the open source repo
- add plugin versions to suppress warnings