### PR TITLE
Upgrading DKPRO and Sweble

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,28 +13,15 @@ json-wikipedia ![json-wikipedia](https://dl.dropboxusercontent.com/u/4663256/tmp
 
 ## Convert the Wikipedia XML to JSON
 
-### The Docker way
-
-Enjoy a dockerized image:
-
-   `docker run -v <LOCALPATH>:/mnt -i -t dav009/jsonwikipedia  -input <PATHTOWIKI> -output <OUTPUTPATH> -lang <LANG> -action export-parallel`
-
- For example if my `english_wikipedia.dump` lives in : `/david/data/english_wikipedia.dump` I could run it as:
-
-   `docker run -v /david/data:/mnt -i -t dav009/jsonwikipedia -input /mnt/english_wikipedia.dump -output /mnt/english_wikipedia.json -lang en -action export-parallel`
-
-Note that the output path corresponds to a path within the docker container. In the given example the output path is part of the mounted volume, so it will be available at the host machine.
-
-
 ### Doing it yourself
 
 1. Compile the project by doing: `mvn assembly:assembly` the command will produce a JAR file containing all the dependencies the target folder.
-2. Download Spark 1.3.1: http://www.apache.org/dyn/closer.cgi/spark/spark-1.3.1/spark-1.3.1.tgz
+2. Download Spark 2.x:
 3. Download Wikipedia Dump ( https://dumps.wikimedia.org/backup-index.html )
 4. Uncompress the Wikipedia Dump
 5. do:
 
-	SPARKFOLDER/bin/spark-submit --driver-memory 10G --class it.cnr.isti.hpc.wikipedia.cli.MediawikiToJsonCLI json-wikipedia-1.0.0-jar-with-dependencies.jar -input <PATHTODBPEDIADUMP> -output <PATHTONEWJSONPEDIA> -lang <LANG> -action export-parallel
+	SPARKFOLDER/bin/spark-submit --driver-memory 10G --class it.cnr.isti.hpc.wikipedia.cli.MediawikiToJsonCLI json-wikipedia-<VERSION>-jar-with-dependencies.jar -input <PATHTODBPEDIADUMP> -output <PATHTONEWJSONPEDIA> -lang <LANG> -action export-parallel
 
 this produces in `<PATHTONEWJSONPEDIA>` the JSON version of the dump
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,13 +72,7 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
         </dependency>
-        <!-- TODO: revert to a proper release when DKPRO 1.2.0 is finally out -->
         <dependency>
-            <groupId>com.github.dkpro</groupId>
-            <artifactId>dkpro-jwpl</artifactId>
-            <version>0a0304b6a0</version>
-        </dependency>
-        <!-- <dependency>
             <groupId>de.tudarmstadt.ukp.wikipedia</groupId>
             <artifactId>de.tudarmstadt.ukp.wikipedia.api</artifactId>
             <version>1.2.0-SNAPSHOT</version>
@@ -102,7 +96,7 @@
             <groupId>de.tudarmstadt.ukp.wikipedia</groupId>
             <artifactId>de.tudarmstadt.ukp.wikipedia.timemachine</artifactId>
             <version>1.2.0-SNAPSHOT</version>
-        </dependency> -->
+        </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -198,14 +198,14 @@
             <id>sonatype-snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
-        <!-- <repository>
+        <repository>
             <id>de.tudarmstadt.ukp.wikipedia</id>
             <url>http://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>always</updatePolicy>
             </snapshots>
-        </repository> -->
+        </repository>
     </repositories>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -72,31 +72,37 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
         </dependency>
+        <!-- TODO: revert to a proper release when DKPRO 1.2.0 is finally out -->
         <dependency>
+            <groupId>com.github.dkpro</groupId>
+            <artifactId>dkpro-jwpl</artifactId>
+            <version>0a0304b6a0</version>
+        </dependency>
+        <!-- <dependency>
             <groupId>de.tudarmstadt.ukp.wikipedia</groupId>
             <artifactId>de.tudarmstadt.ukp.wikipedia.api</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>de.tudarmstadt.ukp.wikipedia</groupId>
             <artifactId>de.tudarmstadt.ukp.wikipedia.parser</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>de.tudarmstadt.ukp.wikipedia</groupId>
             <artifactId>de.tudarmstadt.ukp.wikipedia.datamachine</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>de.tudarmstadt.ukp.wikipedia</groupId>
             <artifactId>de.tudarmstadt.ukp.wikipedia.revisionmachine</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>de.tudarmstadt.ukp.wikipedia</groupId>
             <artifactId>de.tudarmstadt.ukp.wikipedia.timemachine</artifactId>
-            <version>1.1.0</version>
-        </dependency>
+            <version>1.2.0-SNAPSHOT</version>
+        </dependency> -->
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>
@@ -159,20 +165,20 @@
         <dependency>
             <groupId>org.sweble.wikitext</groupId>
             <artifactId>swc-parser-lazy</artifactId>
-            <version>1.1.0</version>
+            <version>3.1.9</version>
         </dependency>
         <dependency>
             <groupId>org.sweble.wikitext</groupId>
             <artifactId>swc-engine</artifactId>
-            <version>1.1.0</version>
+            <version>3.1.9</version>
         </dependency>
     </dependencies>
-    <!-- repositories> <repository> <id>lilyproject</id> <url>http://www.lilyproject.org/maven/maven2/deploy/</url> 
-        <releases> <enabled>true</enabled> </releases> <snapshots> <enabled>false</enabled> 
-        </snapshots> </repository> <repository> <id>info-bliki-repository</id> <url>http://gwtwiki.googlecode.com/svn/maven-repository/</url> 
-        <releases> <enabled>true</enabled> </releases> <snapshots> <enabled>false</enabled> 
-        </snapshots> </repository> <repository> <id>ontotext</id> <url>http://maven.ontotext.com/content/repositories/public/</url> 
-        <releases> <enabled>true</enabled> </releases> <snapshots> <enabled>false</enabled> 
+    <!-- repositories> <repository> <id>lilyproject</id> <url>http://www.lilyproject.org/maven/maven2/deploy/</url>
+        <releases> <enabled>true</enabled> </releases> <snapshots> <enabled>false</enabled>
+        </snapshots> </repository> <repository> <id>info-bliki-repository</id> <url>http://gwtwiki.googlecode.com/svn/maven-repository/</url>
+        <releases> <enabled>true</enabled> </releases> <snapshots> <enabled>false</enabled>
+        </snapshots> </repository> <repository> <id>ontotext</id> <url>http://maven.ontotext.com/content/repositories/public/</url>
+        <releases> <enabled>true</enabled> </releases> <snapshots> <enabled>false</enabled>
         </snapshots> </repository> </repositories -->
     <repositories>
         <repository>
@@ -198,14 +204,14 @@
             <id>sonatype-snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
-        <repository>
+        <!-- <repository>
             <id>de.tudarmstadt.ukp.wikipedia</id>
             <url>http://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>always</updatePolicy>
             </snapshots>
-        </repository>
+        </repository> -->
     </repositories>
     <build>
         <plugins>
@@ -223,7 +229,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>
-                     <finalName>${project.artifactId}-${project.customVersion}</finalName>
+                    <finalName>${project.artifactId}-${project.customVersion}</finalName>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
@@ -247,8 +253,8 @@
                         <id>scala-compile-first</id>
                         <phase>process-resources</phase>
                         <goals>
-                        <goal>add-source</goal>
-                        <goal>compile</goal>
+                            <goal>add-source</goal>
+                            <goal>compile</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Connects to #53 
This adds a version of DKPRO that has fixes for the language configurator and some other niceties.
This paves the way for having japanese jsonpedias and so on.
Note that we are using jitpack to resolve the dependency because DKPRO hasn't been released yet (there might be some broken things there still that we need to dig out). 