### PR TITLE
Tagging module pages

### DIFF
--- a/src/main/java/it/cnr/isti/hpc/wikipedia/article/Article.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/article/Article.java
@@ -40,7 +40,7 @@ public class Article {
 	/** The possible types of an article (e.g., template, article, category) **/
 	public enum Type {
 		TEMPLATE, ARTICLE, CATEGORY, DISCUSSION, REDIRECT, DISAMBIGUATION, UNKNOWN, MAIN, LIST, PROJECT, FILE,
-		HELP, HELPTALK, USER, USERTALK
+		HELP, HELPTALK, USER, USERTALK, MODULE
 	};
 
 	protected String title = NOTITLE;

--- a/src/main/java/it/cnr/isti/hpc/wikipedia/reader/WikipediaArticleReader.java
+++ b/src/main/java/it/cnr/isti/hpc/wikipedia/reader/WikipediaArticleReader.java
@@ -172,7 +172,12 @@ public class WikipediaArticleReader {
 				type = Type.USERTALK;
 				return;
 			}
-
+			
+			if (page.isModule()){
+				type = Type.MODULE;
+				return;
+			}
+			
 			if (page.isProject()) {
 				type = Type.PROJECT;
 				return;


### PR DESCRIPTION
[ch68108]
currently we are passing wikipedia modules as articles. [Wikipedia modules](https://en.wikipedia.org/wiki/Wikipedia:Lua), contain source code used for wikipedia internals. Those pages can be quite long and we can't extract anything from them.

module pages take so long to run through snowballtokenizer, and spotter

In this PR:
- Bliki already has a method for checking if a page is a wikipedia module : `isModule`
- This PR  tag those pages as `module` so we can skip them  later down the pipeline

example module page: https://simple.wikipedia.org/wiki/Module:ISO_639/data